### PR TITLE
resources folder is missing from sketch sample

### DIFF
--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -135,6 +135,23 @@
     <Content Include="Samples\*\*\*.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\arrow.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\brush.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\circle.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\clear.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\edit.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\ellipse.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\freehand-polyline.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\multipoint.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\point.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\polygon.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\polyline.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\rectangle.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\redo.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\save.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\trash-can-outline.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\triangle.png" />
+    <Resource Include="Samples\GraphicsOverlay\SketchOnMap\resources\undo.png" />
     <Page Include="Samples\**\*.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Page>


### PR DESCRIPTION
# Description
Addresses https://devtopia.esri.com/runtime/dotnet-api/issues/11418

Summary of the change and any relevant info.

## Type of change
Included resource folder.

<!--- Delete any that don't apply -->

- [x] Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [x] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
