### PR TITLE
QueryFeatureCountAndExtent: populate ItemSource without loop and feature sample

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -50,11 +50,8 @@ namespace ArcGIS.Samples.QueryFeatureCountAndExtent
 
         private async Task Initialize()
         {
-            // Populate the ComboBox with states.
-            foreach (var state in _states)
-            {
-                StatesPicker.Items.Add(state.Key);
-            }
+            // Populate the Picker with states.
+            StatesPicker.ItemsSource = new List<string>(this._states.Keys);
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);

--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -51,7 +51,7 @@ namespace ArcGIS.Samples.QueryFeatureCountAndExtent
         private async Task Initialize()
         {
             // Populate the Picker with states.
-            StatesPicker.ItemsSource = new List<string>(this._states.Keys);
+            StatesPicker.ItemsSource = _states.Keys.ToList();
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);

--- a/src/Samples.Shared/Resources/FeaturedSamples.xml
+++ b/src/Samples.Shared/Resources/FeaturedSamples.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <FeaturedSamples>
 	<Categories>
+		<Category name="Analysis">
+			<Sample>QueryFeatureCountAndExtent</Sample>
+		</Category>
 		<Category name="Data">
 			<Sample>AddFeaturesWithContingentValues</Sample>
 			<Sample>CreateMobileGeodatabase</Sample>

--- a/src/WPF/WPF.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGIS.WPF.Samples.QueryFeatureCountAndExtent
         private async Task Initialize()
         {
             // Populate the ComboBox with states.
-            StatesComboBox.ItemsSource = new List<string>(this._states.Keys);
+            StatesComboBox.ItemsSource = _states.Keys;
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);

--- a/src/WPF/WPF.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -55,10 +55,7 @@ namespace ArcGIS.WPF.Samples.QueryFeatureCountAndExtent
         private async Task Initialize()
         {
             // Populate the ComboBox with states.
-            foreach (var state in _states)
-            {
-                StatesComboBox.Items.Add(state.Key);
-            }
+            StatesComboBox.ItemsSource = new List<string>(this._states.Keys);
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -55,10 +55,7 @@ namespace ArcGIS.WinUI.Samples.QueryFeatureCountAndExtent
         private async Task Initialize()
         {
             // Populate the ComboBox with states.
-            foreach (var state in _states)
-            {
-                StatesComboBox.Items.Add(state.Key);
-            }
+            StatesComboBox.ItemsSource = new List<string>(this._states.Keys);
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGIS.WinUI.Samples.QueryFeatureCountAndExtent
         private async Task Initialize()
         {
             // Populate the ComboBox with states.
-            StatesComboBox.ItemsSource = new List<string>(this._states.Keys);
+            StatesComboBox.ItemsSource = _states.Keys;
 
             // Create the map with a basemap.
             Map myMap = new Map(BasemapStyle.ArcGISDarkGray);


### PR DESCRIPTION
# Description

- Populate the state picker via the `ItemSource` rather than `Add()`.
- Feature the sample.

## Type of change

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI 

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
