### PR TITLE
Improve image sizing on mobile platforms in MAUI sample viewer

### DIFF
--- a/src/MAUI/Maui.Samples/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml
@@ -39,9 +39,7 @@
                                 Margin="5"
                                 StrokeThickness="{OnPlatform Default=0,
                                                              Android=1}"
-                                WidthRequest="{OnPlatform Default=400,
-                                                          WinUI=300,
-                                                          iOS=400}">
+                                WidthRequest="{Binding SampleImageWidth}">
                                 <Border.GestureRecognizers>
                                     <TapGestureRecognizer CommandParameter="{Binding SampleObject}" Tapped="TapGestureRecognizer_SampleTapped" />
                                     <PointerGestureRecognizer PointerEntered="PointerGestureRecognizer_PointerEntered" />
@@ -54,13 +52,9 @@
                                     </Grid.RowDefinitions>
                                     <Image
                                         Grid.Row="0"
-                                        HeightRequest="{OnPlatform Default=-1,
-                                                                   MacCatalyst=300,
-                                                                   iOS=280}"
+                                        HeightRequest="{Binding SampleImageHeight}"
                                         Source="{Binding SampleImageName, Converter={StaticResource SampleToBitmapConverter}}"
-                                        WidthRequest="{OnPlatform Default=400,
-                                                                  iOS=375,
-                                                                  WinUI=300}" />
+                                        WidthRequest="{Binding SampleImageWidth}" />
                                     <ImageButton
                                         x:Name="FavoriteButton"
                                         Grid.Row="0"

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -27,6 +27,13 @@ namespace ArcGIS.ViewModels
             var displayDensity = DeviceDisplay.MainDisplayInfo.Density;
 
             sampleImageWidth = displayWidth / displayDensity - 20;
+            
+            var sampleImageFactor = Math.Floor(sampleImageWidth / 400);
+
+            if (sampleImageFactor > 1)
+            {
+                sampleImageWidth = sampleImageWidth / sampleImageFactor;
+            }
 #endif
 
             double sampleImageHeight = Math.Floor(sampleImageWidth * 3 / 4);

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -22,10 +22,11 @@ namespace ArcGIS.ViewModels
 
 #elif IOS || ANDROID
 
-            var displayWidth = DeviceDisplay.MainDisplayInfo.Width;
+            var displayWidth = DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Portrait ? DeviceDisplay.MainDisplayInfo.Width : DeviceDisplay.MainDisplayInfo.Height;
+
             var displayDensity = DeviceDisplay.MainDisplayInfo.Density;
 
-            sampleImageWidth = displayWidth / displayDensity - 10;
+            sampleImageWidth = displayWidth / displayDensity - 20;
 #endif
 
             double sampleImageHeight = Math.Floor(sampleImageWidth * 3 / 4);

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -14,9 +14,25 @@ namespace ArcGIS.ViewModels
         {
             _samplesItems = new ObservableCollection<SampleViewModel>();
 
+            double sampleImageWidth = 400;
+
+#if WINDOWS
+
+            sampleImageWidth  = 300;
+
+#elif IOS || ANDROID
+
+            var displayWidth = DeviceDisplay.MainDisplayInfo.Width;
+            var displayDensity = DeviceDisplay.MainDisplayInfo.Density;
+
+            sampleImageWidth = displayWidth / displayDensity - 10;
+#endif
+
+            double sampleImageHeight = Math.Floor(sampleImageWidth * 3 / 4);
+
             foreach (var sampleInfo in sampleInfos)
             {
-                SamplesItems.Add(new SampleViewModel(sampleInfo));
+                SamplesItems.Add(new SampleViewModel(sampleInfo, sampleImageWidth, sampleImageHeight));
             }
 
             _category = category;
@@ -43,7 +59,7 @@ namespace ArcGIS.ViewModels
 
     public partial class SampleViewModel : ObservableObject
     {
-        public SampleViewModel(SampleInfo sampleInfo)
+        public SampleViewModel(SampleInfo sampleInfo, double sampleImageWidth, double sampleImageHeight)
         {
             SampleObject = sampleInfo;
             SampleName = sampleInfo.SampleName;
@@ -51,6 +67,8 @@ namespace ArcGIS.ViewModels
             Description = sampleInfo.Description;
             SampleImageName = sampleInfo.SampleImageName;
             IsFavorite = sampleInfo.IsFavorite;
+            SampleImageWidth = sampleImageWidth;
+            SampleImageHeight = sampleImageHeight;
         }
 
         [ObservableProperty]
@@ -70,6 +88,12 @@ namespace ArcGIS.ViewModels
 
         [ObservableProperty]
         SampleInfo _sampleObject;
+
+        [ObservableProperty]
+        double _sampleImageWidth;
+
+        [ObservableProperty]
+        double _sampleImageHeight;
 
     }
 }


### PR DESCRIPTION
# Description

Updated the MAUI sample viewer to set the sample image sized based on device display size to improve functionality on mobile and tablet platforms. 

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
