### PR TITLE
MAUI.MacCatalyst/iOS scrollbar fix

### DIFF
--- a/src/MAUI/Maui.Samples/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml
@@ -18,10 +18,10 @@
             Text="Source" />
     </ContentPage.ToolbarItems>
     <Grid>
-        <Border x:Name="SampleDetailPage" IsVisible="false">
+        <Border x:Name="SampleDetailPage">
             <WebView x:Name="DescriptionView" />
         </Border>
-        <Border x:Name="SourceCodePage" IsVisible="false">
+        <Border x:Name="SourceCodePage">
             <StackLayout>
                 <StackLayout Orientation="Horizontal">
                     <Button


### PR DESCRIPTION
# Description

When viewing a sample's code or information, the scrollbars aren't set to the upper right corner, where a user would begin reading. This issue is specific to MAUI.MacCatalyst/iOS, and is caused by setting the visibility of the borders to false.

## Type of change

- Bug fix

## Platforms tested on

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
