### PR TITLE
Fix MAUI windows crash on start up in release mode

### DIFF
--- a/src/MAUI/Maui.Samples/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml
@@ -21,7 +21,7 @@
 
     <ContentPage.Resources>
         <converters:SampleToBitmapConverter x:Key="SampleToBitmapConverter" />
-        <converters:BoolToFavoriteGlyphConverter x:Key="BoolToFavoriteGlyphConverter" />
+        <converters:BoolToImageSourceConverter x:Key="BoolToImageSourceConverter" />
     </ContentPage.Resources>
     <Grid x:Name="SampleListGrid">
         <ScrollView x:Name="SampleScrollView" HorizontalOptions="Center">
@@ -53,28 +53,28 @@
                                     <Image
                                         Grid.Row="0"
                                         HeightRequest="{Binding SampleImageHeight}"
-                                        Source="{Binding SampleImageName}"
+                                        Source="{Binding SampleImageName, Converter={StaticResource SampleToBitmapConverter}}"
                                         WidthRequest="{Binding SampleImageWidth}" />
-
-                                    <Button FontFamily="calcite-ui-icons-24"
-                                        Text="{Binding IsFavorite, Converter={StaticResource BoolToFavoriteGlyphConverter}}"
+                                    <ImageButton
                                         x:Name="FavoriteButton"
                                         Grid.Row="0"
-                                        Margin="5"
+                                        Margin="1,0"
                                         Padding="1"
                                         Background="#A52F2F2F"
+                                        BorderColor="Black"
+                                        BorderWidth="1"
                                         Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:CategoryViewModel}}, Path=UpdateFavoriteCommand}"
                                         CommandParameter="{Binding SampleFormalName}"
+                                        HeightRequest="{OnPlatform Default=25,
+                                                                   iOS=40,
+                                                                   Android=40}"
                                         HorizontalOptions="Start"
-                                        TextColor="Yellow" 
-                                        IsVisible="{OnPlatform iOS=true,
-                                                               Android=true,
-                                                               Default={Binding IsFavorite}}"
+                                        IsVisible="{Binding ShowFavoriteIcon}"
+                                        Source="{Binding IsFavorite, Converter={StaticResource BoolToImageSourceConverter}}"
                                         VerticalOptions="Start"
-                                        FontSize="{OnPlatform Default=25,
+                                        WidthRequest="{OnPlatform Default=25,
                                                                   iOS=40,
                                                                   Android=40}" />
-
                                     <Grid
                                         Grid.Row="0"
                                         BackgroundColor="#A52F2F2F"

--- a/src/MAUI/Maui.Samples/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml
@@ -69,7 +69,7 @@
                                                                    iOS=40,
                                                                    Android=40}"
                                         HorizontalOptions="Start"
-                                        IsVisible="{Binding IsFavorite}"
+                                        IsVisible="{Binding ShowFavoriteIcon}"
                                         Source="{Binding IsFavorite, Converter={StaticResource BoolToImageSourceConverter}}"
                                         VerticalOptions="Start"
                                         WidthRequest="{OnPlatform Default=25,

--- a/src/MAUI/Maui.Samples/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml
@@ -21,7 +21,7 @@
 
     <ContentPage.Resources>
         <converters:SampleToBitmapConverter x:Key="SampleToBitmapConverter" />
-        <converters:BoolToImageSourceConverter x:Key="BoolToImageSourceConverter" />
+        <converters:BoolToFavoriteGlyphConverter x:Key="BoolToFavoriteGlyphConverter" />
     </ContentPage.Resources>
     <Grid x:Name="SampleListGrid">
         <ScrollView x:Name="SampleScrollView" HorizontalOptions="Center">
@@ -53,28 +53,26 @@
                                     <Image
                                         Grid.Row="0"
                                         HeightRequest="{Binding SampleImageHeight}"
-                                        Source="{Binding SampleImageName, Converter={StaticResource SampleToBitmapConverter}}"
+                                        Source="{Binding SampleImageName}"
                                         WidthRequest="{Binding SampleImageWidth}" />
-                                    <ImageButton
+
+                                    <Button FontFamily="calcite-ui-icons-24"
+                                        Text="{Binding IsFavorite, Converter={StaticResource BoolToFavoriteGlyphConverter}}"
                                         x:Name="FavoriteButton"
                                         Grid.Row="0"
-                                        Margin="1,0"
+                                        Margin="5"
                                         Padding="1"
                                         Background="#A52F2F2F"
-                                        BorderColor="Black"
-                                        BorderWidth="1"
                                         Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:CategoryViewModel}}, Path=UpdateFavoriteCommand}"
                                         CommandParameter="{Binding SampleFormalName}"
-                                        HeightRequest="{OnPlatform Default=25,
-                                                                   iOS=40,
-                                                                   Android=40}"
                                         HorizontalOptions="Start"
+                                        TextColor="Yellow" 
                                         IsVisible="{Binding ShowFavoriteIcon}"
-                                        Source="{Binding IsFavorite, Converter={StaticResource BoolToImageSourceConverter}}"
                                         VerticalOptions="Start"
-                                        WidthRequest="{OnPlatform Default=25,
+                                        FontSize="{OnPlatform Default=25,
                                                                   iOS=40,
                                                                   Android=40}" />
+
                                     <Grid
                                         Grid.Row="0"
                                         BackgroundColor="#A52F2F2F"

--- a/src/MAUI/Maui.Samples/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml
@@ -69,7 +69,7 @@
                                                                    iOS=40,
                                                                    Android=40}"
                                         HorizontalOptions="Start"
-                                        IsVisible="{Binding ShowFavoriteIcon}"
+                                        IsVisible="{Binding IsFavorite}"
                                         Source="{Binding IsFavorite, Converter={StaticResource BoolToImageSourceConverter}}"
                                         VerticalOptions="Start"
                                         WidthRequest="{OnPlatform Default=25,

--- a/src/MAUI/Maui.Samples/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml.cs
@@ -87,8 +87,9 @@ public partial class CategoryPage : ContentPage
         if (_category.Name == "Favorites")
         {
             _category = SampleManager.Current.GetFavoritesCategory();
-
-            SetBindingContext();
         }
+
+        SetBindingContext();
+        
     }
 }

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -67,6 +67,8 @@ namespace ArcGIS.ViewModels
             {
                 SamplesItems.Remove(sample);
             }
+
+            
         }
     }
 
@@ -80,6 +82,7 @@ namespace ArcGIS.ViewModels
             Description = sampleInfo.Description;
             SampleImageName = sampleInfo.SampleImageName;
             IsFavorite = sampleInfo.IsFavorite;
+            ShowFavoriteIcon = sampleInfo.ShowFavoriteIcon;
             SampleImageWidth = sampleImageWidth;
             SampleImageHeight = sampleImageHeight;
         }

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -80,6 +80,7 @@ namespace ArcGIS.ViewModels
             Description = sampleInfo.Description;
             SampleImageName = sampleInfo.SampleImageName;
             IsFavorite = sampleInfo.IsFavorite;
+            ShowFavoriteIcon=sampleInfo.ShowFavoriteIcon;
             SampleImageWidth = sampleImageWidth;
             SampleImageHeight = sampleImageHeight;
         }
@@ -95,6 +96,9 @@ namespace ArcGIS.ViewModels
 
         [ObservableProperty]
         bool _isFavorite;
+
+        [ObservableProperty]
+        bool _showFavoriteIcon;
 
         [ObservableProperty]
         string _sampleImageName;

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -80,7 +80,6 @@ namespace ArcGIS.ViewModels
             Description = sampleInfo.Description;
             SampleImageName = sampleInfo.SampleImageName;
             IsFavorite = sampleInfo.IsFavorite;
-            ShowFavoriteIcon=sampleInfo.ShowFavoriteIcon;
             SampleImageWidth = sampleImageWidth;
             SampleImageHeight = sampleImageHeight;
         }

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -62,18 +62,21 @@ namespace ArcGIS.Samples.Shared.Models
 
         public bool IsFavorite { get; set; }
 
+
         public bool ShowFavoriteIcon
         {
             get
             {
                 // Determine if on mobile.
-                var device = DeviceInfo.Current.Platform;
-                bool isMobile = device.Equals(DevicePlatform.Android) || device.Equals(DevicePlatform.iOS);
-
+                bool isMobile;
+#if ANDROID || IOS
+                isMobile = true;
+#else
+                isMobile = false;
+#endif
                 // Always show icons on mobile platforms; on desktop, only show yellow stars.
                 return isMobile || SampleManager.Current.IsSampleFavorited(FormalName);
             }
-
         }
 
         /// <summary>

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using ArcGIS.Samples.Shared.Attributes;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18,6 +19,7 @@ namespace ArcGIS.Samples.Shared.Models
 {
     public partial class SampleInfo
     {
+        private bool _showFavoriteIcon;
 #if NETFX_CORE
         private string _pathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
 #else
@@ -61,6 +63,23 @@ namespace ArcGIS.Samples.Shared.Models
 
         public bool IsFavorite { get; set; }
 
+        public bool ShowFavoriteIcon
+        {
+            get { return _showFavoriteIcon; }
+            set
+            {
+#if (__IOS__ || __ANDROID__)
+                {
+                    _showFavoriteIcon = true;
+                }
+#else
+                {
+                _showFavoriteIcon=IsFavorite;
+                }
+#endif
+
+            }
+        }
         /// <summary>
         /// A list of offline data items that should be downloaded
         /// from ArcGIS Online prior to loading the sample. These

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -60,11 +60,12 @@ namespace ArcGIS.Samples.Shared.Models
 
         public string Instructions { get; set; }
 
-        public bool IsFavorite { get; set; }
-
-        public bool ShowFavoriteIcon
-        {
-            get { return _showFavoriteIcon; }
+        public bool IsFavorite 
+        { 
+            get
+            { 
+                return _showFavoriteIcon; 
+            }
             set
             {
 #if (__IOS__ || __ANDROID__)
@@ -73,12 +74,12 @@ namespace ArcGIS.Samples.Shared.Models
                 }
 #else
                 {
-                _showFavoriteIcon=IsFavorite;
+                    _showFavoriteIcon = value;
                 }
 #endif
-
             }
         }
+
         /// <summary>
         /// A list of offline data items that should be downloaded
         /// from ArcGIS Online prior to loading the sample. These

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -8,7 +8,6 @@
 // language governing permissions and limitations under the License.
 
 using ArcGIS.Samples.Shared.Attributes;
-using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -7,6 +7,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGIS.Samples.Managers;
 using ArcGIS.Samples.Shared.Attributes;
 using System;
 using System.Collections.Generic;
@@ -18,7 +19,6 @@ namespace ArcGIS.Samples.Shared.Models
 {
     public partial class SampleInfo
     {
-        private bool _showFavoriteIcon;
 #if NETFX_CORE
         private string _pathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
 #else
@@ -60,24 +60,20 @@ namespace ArcGIS.Samples.Shared.Models
 
         public string Instructions { get; set; }
 
-        public bool IsFavorite 
-        { 
+        public bool IsFavorite { get; set; }
+
+        public bool ShowFavoriteIcon
+        {
             get
-            { 
-                return _showFavoriteIcon; 
-            }
-            set
             {
-#if (__IOS__ || __ANDROID__)
-                {
-                    _showFavoriteIcon = true;
-                }
-#else
-                {
-                    _showFavoriteIcon = value;
-                }
-#endif
+                // Determine if on mobile.
+                var device = DeviceInfo.Current.Platform;
+                bool isMobile = device.Equals(DevicePlatform.Android) || device.Equals(DevicePlatform.iOS);
+
+                // Always show icons on mobile platforms; on desktop, only show yellow stars.
+                return isMobile || SampleManager.Current.IsSampleFavorited(FormalName);
             }
+
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses an issue that looks like a MAUI issue. Issue is with using binding for `OnPlatform` attribute. It throws an `InvalidCastException` when app is started/deployed.

# Description

Added a new property to handle visibility of favorite icon.


## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
