### PR TITLE
Fix issue with sample page when screenshot tool is enabled

### DIFF
--- a/src/MAUI/Maui.Samples/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml
@@ -18,10 +18,10 @@
             Text="Source" />
     </ContentPage.ToolbarItems>
     <Grid>
-        <Border x:Name="SampleDetailPage">
+        <Border x:Name="SampleDetailPage" IsVisible="false">
             <WebView x:Name="DescriptionView" />
         </Border>
-        <Border x:Name="SourceCodePage">
+        <Border x:Name="SourceCodePage" IsVisible="false">
             <StackLayout>
                 <StackLayout Orientation="Horizontal">
                     <Button


### PR DESCRIPTION
# Description

Fixed an issue that resulted in the source code and description pages showing behind the sample container when the screenshot tool is enabled. 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
