### PR TITLE
Update MAUI screenshot tool names

### DIFF
--- a/src/MAUI/Maui.Samples/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml.cs
@@ -376,7 +376,7 @@ namespace ArcGIS
             string filePath = $"{ScreenshotManager.ScreenshotSettings.SourcePath}\\MAUI\\MAUI.Samples\\Samples\\" +
                 $"{SampleManager.Current.SelectedSample.Category}\\" +
                 $"{SampleManager.Current.SelectedSample.FormalName}\\" +
-                $"{SampleManager.Current.SelectedSample.FormalName}.jpg";
+                $"{SampleManager.Current.SelectedSample.FormalName.ToLower()}.jpg";
 
             // Remove white space.
             filePath = Regex.Replace(filePath, @"\s+", "");


### PR DESCRIPTION
# Description

MAUI Android requires MauiImage names to be all lowercase. This change updates the screenshot tool to account for this requirement. 

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
