### PR TITLE
Update markdown styling rules in the GitHub Action 

### DIFF
--- a/tools/CI/README_Metadata_StyleCheck/style.rb
+++ b/tools/CI/README_Metadata_StyleCheck/style.rb
@@ -5,3 +5,4 @@ rule 'MD009', :br_spaces => 2  # Allows an exception for 2 trailing spaces used 
 rule 'MD029', :style => :ordered  # Ordered list item prefix is incremental, rather than all ones
 exclude_rule 'MD013'  # Not limiting line length
 exclude_rule 'MD007'  # Not limiting unordered list indentation, tab, 2 or 4 spaces are all fine
+exclude_rule 'MD034'  # Not using angle brackets around URLs


### PR DESCRIPTION
# Description

Removed one of the rules in the markdown styling rules that we are not adhering to in our samples readmes.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement
