### PR TITLE
Updated copyright year to 2023 in all files

### DIFF
--- a/src/MAUI/Maui.Samples/ApiKeyView.xaml.cs
+++ b/src/MAUI/Maui.Samples/ApiKeyView.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Converters/NullToVisibilityConverter.cs
+++ b/src/MAUI/Maui.Samples/Converters/NullToVisibilityConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
+++ b/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Resources/IARSample.cs
+++ b/src/MAUI/Maui.Samples/Resources/IARSample.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightLocation/LineOfSightLocation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightLocation/LineOfSightLocation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedCamera/ViewshedCamera.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedCamera/ViewshedCamera.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/ViewshedLocation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/ViewshedLocation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: https://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Data/ViewPointCloudDataOffline/ViewPointCloudDataOffline.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ViewPointCloudDataOffline/ViewPointCloudDataOffline.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/BufferList.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/BufferList.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ClipGeometry/ClipGeometry.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ClipGeometry/ClipGeometry.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/CreateGeometries/CreateGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CreateGeometries/CreateGeometries.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/CutGeometry/CutGeometry.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CutGeometry/CutGeometry.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/GeodesicOperations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/GeodesicOperations.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Project/Project.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Project/Project.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ProjectWithSpecificTransformation/ProjectWithSpecificTransformation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ProjectWithSpecificTransformation/ProjectWithSpecificTransformation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddAnIntegratedMeshLayer/AddAnIntegratedMeshLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddAnIntegratedMeshLayer/AddAnIntegratedMeshLayer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddPointSceneLayer/AddPointSceneLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddPointSceneLayer/AddPointSceneLayer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/ApplyMosaicRule.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/ApplyMosaicRule.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/EditKmlGroundOverlay/EditKmlGroundOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/EditKmlGroundOverlay/EditKmlGroundOverlay.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/OpenStreetMapLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/OpenStreetMapLayer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/RasterColormapRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/RasterColormapRenderer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerImageServiceRaster/RasterLayerImageServiceRaster.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerImageServiceRaster/RasterLayerImageServiceRaster.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMSLayerUrl/WMSLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMSLayerUrl/WMSLayerUrl.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/AccessLoadStatus/AccessLoadStatus.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/AccessLoadStatus/AccessLoadStatus.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/ChangeBasemap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/ChangeBasemap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/DisplayMap/DisplayMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/DisplayMap/DisplayMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/DisplayOverviewMap/DisplayOverviewMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/DisplayOverviewMap/DisplayOverviewMap.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapArea/SetInitialMapArea.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapArea/SetInitialMapArea.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/SetMaxExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/SetMaxExtent.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMinMaxScale/SetMinMaxScale.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMinMaxScale/SetMinMaxScale.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/DisplayGrid.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/DisplayGrid.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/FilterByTimeExtent/FilterByTimeExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FilterByTimeExtent/FilterByTimeExtent.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/MapRotation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/MapRotation.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/ShowCallout.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/ShowCallout.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/ClosestFacility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/ClosestFacility.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/ChangeAtmosphereEffect.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/ChangeAtmosphereEffect.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceRaster/CreateTerrainSurfaceRaster.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceRaster/CreateTerrainSurfaceRaster.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceTilePackage/CreateTerrainSurfaceTilePackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceTilePackage/CreateTerrainSurfaceTilePackage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/OpenScenePortalItem.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/OpenScenePortalItem.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/ShowLabelsOnLayer3D.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/ShowLabelsOnLayer3D.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Scene/ViewContentBeneathSurface/ViewContentBeneathSurface.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ViewContentBeneathSurface/ViewContentBeneathSurface.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/SceneView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/GeoViewSync/GeoViewSync.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderMultilayerSymbols/RenderMultilayerSymbols.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderMultilayerSymbols/RenderMultilayerSymbols.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderSimpleMarkers/RenderSimpleMarkers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderSimpleMarkers/RenderSimpleMarkers.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderUniqueValues/RenderUniqueValues.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderUniqueValues/RenderUniqueValues.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SceneSymbols/SceneSymbols.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SceneSymbols/SceneSymbols.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SimpleRenderers/SimpleRenderers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SimpleRenderers/SimpleRenderers.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/UniqueValuesAlternateSymbols.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/UniqueValuesAlternateSymbols.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/Symbology/UseDistanceCompositeSym/UseDistanceCompositeSym.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/UseDistanceCompositeSym/UseDistanceCompositeSym.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Esri.
+// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/SettingsPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/SettingsPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/MAUI/Maui.Samples/WaitPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/WaitPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/Samples.Shared/Managers/FileDownloadTask.cs
+++ b/src/Samples.Shared/Managers/FileDownloadTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Esri.
+﻿// Copyright 2023 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
# Description
Updated copyright year to 2023 in all files

Summary of the change and any relevant info.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
