### PR TITLE
Metadata image names lowercase

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DistanceMeasurement",
     "ignore": false,
     "images": [
-        "DistanceMeasurement.jpg"
+        "distancemeasurement.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "LineOfSightGeoElement",
     "ignore": false,
     "images": [
-        "LineOfSightGeoElement.jpg"
+        "lineofsightgeoelement.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightLocation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightLocation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "LineOfSightLocation",
     "ignore": false,
     "images": [
-        "LineOfSightLocation.jpg"
+        "lineofsightlocation.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "QueryFeatureCountAndExtent",
     "ignore": false,
     "images": [
-        "QueryFeatureCountAndExtent.jpg"
+        "queryfeaturecountandextent.jpg"
     ],
     "keywords": [
         "count",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedCamera/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedCamera/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ViewshedCamera",
     "ignore": false,
     "images": [
-        "ViewshedCamera.jpg"
+        "viewshedcamera.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ViewshedGeoElement",
     "ignore": false,
     "images": [
-        "ViewshedGeoElement.jpg"
+        "viewshedgeoelement.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ViewshedLocation",
     "ignore": false,
     "images": [
-        "ViewshedLocation.jpg"
+        "viewshedlocation.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddFeaturesWithContingentValues",
     "ignore": false,
     "images": [
-        "AddFeaturesWithContingentValues.jpg"
+        "addfeatureswithcontingentvalues.jpg"
     ],
     "keywords": [
         "coded values",

--- a/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateMobileGeodatabase",
     "ignore": false,
     "images": [
-        "CreateMobileGeodatabase.jpg"
+        "createmobilegeodatabase.jpg"
     ],
     "keywords": [
         "arcgis pro",

--- a/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "EditAndSyncFeatures",
     "ignore": false,
     "images": [
-        "EditAndSyncFeatures.jpg"
+        "editandsyncfeatures.jpg"
     ],
     "keywords": [
         "feature service",

--- a/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "EditBranchVersioning",
     "ignore": false,
     "images": [
-        "EditBranchVersioning.jpg"
+        "editbranchversioning.jpg"
     ],
     "keywords": [
         "branch versioning",

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "EditFeatureAttachments",
     "ignore": false,
     "images": [
-        "EditFeatureAttachments.jpg"
+        "editfeatureattachments.jpg"
     ],
     "keywords": [
         "JPEG",

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "EditFeatureLinkedAnnotation",
     "ignore": false,
     "images": [
-        "EditFeatureLinkedAnnotation.jpg"
+        "editfeaturelinkedannotation.jpg"
     ],
     "keywords": [
         "annotation",

--- a/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerQuery",
     "ignore": false,
     "images": [
-        "FeatureLayerQuery.jpg"
+        "featurelayerquery.jpg"
     ],
     "keywords": [
         "query",

--- a/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GenerateGeodatabaseReplica",
     "ignore": false,
     "images": [
-        "GenerateGeodatabaseReplica.jpg"
+        "generategeodatabasereplica.jpg"
     ],
     "keywords": [
         "disconnected",

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GeodatabaseTransactions",
     "ignore": false,
     "images": [
-        "GeodatabaseTransactions.jpg"
+        "geodatabasetransactions.jpg"
     ],
     "keywords": [
         "commit",

--- a/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ListRelatedFeatures",
     "ignore": false,
     "images": [
-        "ListRelatedFeatures.jpg"
+        "listrelatedfeatures.jpg"
     ],
     "keywords": [
         "features",

--- a/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ManageFeatures",
     "ignore": false,
     "images": [
-        "ManageFeatures.jpg"
+        "managefeatures.jpg"
     ],
     "keywords": [
         "amend",

--- a/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "QueryFeaturesWithArcadeExpression",
     "ignore": false,
     "images": [
-        "QueryFeaturesWithArcadeExpression.jpg"
+        "queryfeatureswitharcadeexpression.jpg"
     ],
     "keywords": [
         "Arcade evaluator",

--- a/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterLayerGeoPackage",
     "ignore": false,
     "images": [
-        "RasterLayerGeoPackage.jpg"
+        "rasterlayergeopackage.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ReadGeoPackage",
     "ignore": false,
     "images": [
-        "ReadGeoPackage.jpg"
+        "readgeopackage.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ReadShapefileMetadata",
     "ignore": false,
     "images": [
-        "ReadShapefileMetadata.jpg"
+        "readshapefilemetadata.jpg"
     ],
     "keywords": [
         "credits",

--- a/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "StatisticalQuery",
     "ignore": false,
     "images": [
-        "StatisticalQuery.jpg"
+        "statisticalquery.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "StatsQueryGroupAndSort",
     "ignore": false,
     "images": [
-        "StatsQueryGroupAndSort.jpg"
+        "statsquerygroupandsort.jpg"
     ],
     "keywords": [
         "correlation",

--- a/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SymbolizeShapefile",
     "ignore": false,
     "images": [
-        "SymbolizeShapefile.jpg"
+        "symbolizeshapefile.jpg"
     ],
     "keywords": [
         "package",

--- a/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ToggleBetweenFeatureRequestModes",
     "ignore": false,
     "images": [
-        "ToggleBetweenFeatureRequestModes.jpg"
+        "togglebetweenfeaturerequestmodes.jpg"
     ],
     "keywords": [
         "cache",

--- a/src/MAUI/Maui.Samples/Samples/Data/ViewPointCloudDataOffline/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ViewPointCloudDataOffline/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ViewPointCloudDataOffline",
     "ignore": false,
     "images": [
-        "ViewPointCloudDataOffline.jpg"
+        "viewpointclouddataoffline.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "Buffer",
     "ignore": false,
     "images": [
-        "Buffer.jpg"
+        "buffer.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "BufferList",
     "ignore": false,
     "images": [
-        "BufferList.jpg"
+        "bufferlist.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ClipGeometry/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ClipGeometry/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ClipGeometry",
     "ignore": false,
     "images": [
-        "ClipGeometry.jpg"
+        "clipgeometry.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ConvexHull",
     "ignore": false,
     "images": [
-        "ConvexHull.jpg"
+        "convexhull.jpg"
     ],
     "keywords": [
         "convex hull",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ConvexHullList",
     "ignore": false,
     "images": [
-        "ConvexHullList.jpg"
+        "convexhulllist.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/CreateGeometries/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CreateGeometries/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateGeometries",
     "ignore": false,
     "images": [
-        "CreateGeometries.jpg"
+        "creategeometries.jpg"
     ],
     "keywords": [
         "area",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/CutGeometry/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CutGeometry/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CutGeometry",
     "ignore": false,
     "images": [
-        "CutGeometry.jpg"
+        "cutgeometry.jpg"
     ],
     "keywords": [
         "cut",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DensifyAndGeneralize",
     "ignore": false,
     "images": [
-        "DensifyAndGeneralize.jpg"
+        "densifyandgeneralize.jpg"
     ],
     "keywords": [
         "data",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FormatCoordinates",
     "ignore": false,
     "images": [
-        "FormatCoordinates.jpg"
+        "formatcoordinates.jpg"
     ],
     "keywords": [
         "USNG",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GeodesicOperations",
     "ignore": false,
     "images": [
-        "GeodesicOperations.jpg"
+        "geodesicoperations.jpg"
     ],
     "keywords": [
         "densify",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ListTransformations",
     "ignore": false,
     "images": [
-        "ListTransformations.jpg"
+        "listtransformations.jpg"
     ],
     "keywords": [
         "datum",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/NearestVertex/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/NearestVertex/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "NearestVertex",
     "ignore": false,
     "images": [
-        "NearestVertex.jpg"
+        "nearestvertex.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Project/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Project/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "Project",
     "ignore": false,
     "images": [
-        "Project.jpg"
+        "project.jpg"
     ],
     "keywords": [
         "WGS 84",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ProjectWithSpecificTransformation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ProjectWithSpecificTransformation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ProjectWithSpecificTransformation",
     "ignore": false,
     "images": [
-        "ProjectWithSpecificTransformation.jpg"
+        "projectwithspecifictransformation.jpg"
     ],
     "keywords": [
         "coordinate system",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SpatialOperations",
     "ignore": false,
     "images": [
-        "SpatialOperations.jpg"
+        "spatialoperations.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SpatialRelationships",
     "ignore": false,
     "images": [
-        "SpatialRelationships.jpg"
+        "spatialrelationships.jpg"
     ],
     "keywords": [
         "geometries",

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AnalyzeHotspots",
     "ignore": false,
     "images": [
-        "AnalyzeHotspots.jpg"
+        "analyzehotspots.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AnalyzeViewshed",
     "ignore": false,
     "images": [
-        "AnalyzeViewshed.jpg"
+        "analyzeviewshed.jpg"
     ],
     "keywords": [
         "geoprocessing",

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ListGeodatabaseVersions",
     "ignore": false,
     "images": [
-        "ListGeodatabaseVersions.jpg"
+        "listgeodatabaseversions.jpg"
     ],
     "keywords": [
         "conflict resolution",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddGraphicsRenderer",
     "ignore": false,
     "images": [
-        "AddGraphicsRenderer.jpg"
+        "addgraphicsrenderer.jpg"
     ],
     "keywords": [
         "arc",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsWithSymbols/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/AddGraphicsWithSymbols/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddGraphicsWithSymbols",
     "ignore": false,
     "images": [
-        "AddGraphicsWithSymbols.jpg"
+        "addgraphicswithsymbols.jpg"
     ],
     "keywords": [
         "display",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "Animate3DGraphic",
     "ignore": false,
     "images": [
-        "Animate3DGraphic.jpg"
+        "animate3dgraphic.jpg"
     ],
     "keywords": [
         "animation",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DictionaryRendererGraphicsOverlay",
     "ignore": false,
     "images": [
-        "DictionaryRendererGraphicsOverlay.jpg"
+        "dictionaryrenderergraphicsoverlay.jpg"
     ],
     "keywords": [
         "defense",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "IdentifyGraphics",
     "ignore": false,
     "images": [
-        "IdentifyGraphics.jpg"
+        "identifygraphics.jpg"
     ],
     "keywords": [
         "graphics",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ScenePropertiesExpressions",
     "ignore": false,
     "images": [
-        "ScenePropertiesExpressions.jpg"
+        "scenepropertiesexpressions.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SketchOnMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SketchOnMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SketchOnMap",
     "ignore": false,
     "images": [
-        "SketchOnMap.jpg"
+        "sketchonmap.jpg"
     ],
     "keywords": [
         "draw",

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SurfacePlacements",
     "ignore": false,
     "images": [
-        "SurfacePlacements.jpg"
+        "surfaceplacements.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddEncExchangeSet",
     "ignore": false,
     "images": [
-        "AddEncExchangeSet.jpg"
+        "addencexchangeset.jpg"
     ],
     "keywords": [
         "Data",

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeEncDisplaySettings",
     "ignore": false,
     "images": [
-        "ChangeEncDisplaySettings.jpg"
+        "changeencdisplaysettings.jpg"
     ],
     "keywords": [
         "ENC",

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SelectEncFeatures",
     "ignore": false,
     "images": [
-        "SelectEncFeatures.jpg"
+        "selectencfeatures.jpg"
     ],
     "keywords": [
         "IHO",

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddAnIntegratedMeshLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddAnIntegratedMeshLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddAnIntegratedMeshLayer",
     "ignore": false,
     "images": [
-        "AddAnIntegratedMeshLayer.jpg"
+        "addanintegratedmeshlayer.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddDynamicEntityLayer",
     "ignore": false,
     "images": [
-        "AddDynamicEntityLayer.jpg"
+        "adddynamicentitylayer.jpg"
     ],
     "keywords": [
         "data",

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddPointSceneLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddPointSceneLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddPointSceneLayer",
     "ignore": false,
     "images": [
-        "AddPointSceneLayer.jpg"
+        "addpointscenelayer.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AddVectorTiledLayerFromCustomStyle",
     "ignore": false,
     "images": [
-        "AddVectorTiledLayerFromCustomStyle.jpg"
+        "addvectortiledlayerfromcustomstyle.jpg"
     ],
     "keywords": [
         "tiles",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ApplyMosaicRule",
     "ignore": false,
     "images": [
-        "ApplyMosaicRule.jpg"
+        "applymosaicrule.jpg"
     ],
     "keywords": [
         "image service",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ArcGISMapImageLayerUrl/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ArcGISMapImageLayerUrl/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ArcGISMapImageLayerUrl",
     "ignore": false,
     "images": [
-        "ArcGISMapImageLayerUrl.jpg"
+        "arcgismapimagelayerurl.jpg"
     ],
     "keywords": [
         "display",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ArcGISTiledLayerUrl/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ArcGISTiledLayerUrl/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ArcGISTiledLayerUrl",
     "ignore": false,
     "images": [
-        "ArcGISTiledLayerUrl.jpg"
+        "arcgistiledlayerurl.jpg"
     ],
     "keywords": [
         "basemap",

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "BrowseOAFeatureService",
     "ignore": false,
     "images": [
-        "BrowseOAFeatureService.jpg"
+        "browseoafeatureservice.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "BrowseWfsLayers",
     "ignore": false,
     "images": [
-        "BrowseWfsLayers.jpg"
+        "browsewfslayers.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeBlendRenderer",
     "ignore": false,
     "images": [
-        "ChangeBlendRenderer.jpg"
+        "changeblendrenderer.jpg"
     ],
     "keywords": [
         "color ramp",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeFeatureLayerRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeFeatureLayerRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeFeatureLayerRenderer",
     "ignore": false,
     "images": [
-        "ChangeFeatureLayerRenderer.jpg"
+        "changefeaturelayerrenderer.jpg"
     ],
     "keywords": [
         "feature layer",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeStretchRenderer",
     "ignore": false,
     "images": [
-        "ChangeStretchRenderer.jpg"
+        "changestretchrenderer.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeSublayerRenderer",
     "ignore": false,
     "images": [
-        "ChangeSublayerRenderer.jpg"
+        "changesublayerrenderer.jpg"
     ],
     "keywords": [
         "class breaks",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeSublayerVisibility",
     "ignore": false,
     "images": [
-        "ChangeSublayerVisibility.jpg"
+        "changesublayervisibility.jpg"
     ],
     "keywords": [
         "layers",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ControlAnnotationSublayerVisibility",
     "ignore": false,
     "images": [
-        "ControlAnnotationSublayerVisibility.jpg"
+        "controlannotationsublayervisibility.jpg"
     ],
     "keywords": [
         "annotation",

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateAndSaveKmlFile",
     "ignore": false,
     "images": [
-        "CreateAndSaveKmlFile.jpg"
+        "createandsavekmlfile.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateFeatureCollectionLayer",
     "ignore": false,
     "images": [
-        "CreateFeatureCollectionLayer.jpg"
+        "createfeaturecollectionlayer.jpg"
     ],
     "keywords": [
         "feature collection",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayAnnotation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayAnnotation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayAnnotation",
     "ignore": false,
     "images": [
-        "DisplayAnnotation.jpg"
+        "displayannotation.jpg"
     ],
     "keywords": [
         "annotation",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayDimensions",
     "ignore": false,
     "images": [
-        "DisplayDimensions.jpg"
+        "displaydimensions.jpg"
     ],
     "keywords": [
         "dimension",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayFeatureLayers",
     "ignore": false,
     "images": [
-        "DisplayFeatureLayers.jpg"
+        "displayfeaturelayers.jpg"
     ],
     "keywords": [
         "feature",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayKml",
     "ignore": false,
     "images": [
-        "DisplayKml.jpg"
+        "displaykml.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayKmlNetworkLinks",
     "ignore": false,
     "images": [
-        "DisplayKmlNetworkLinks.jpg"
+        "displaykmlnetworklinks.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayOACollection",
     "ignore": false,
     "images": [
-        "DisplayOACollection.jpg"
+        "displayoacollection.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayRouteLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayRouteLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayRouteLayer",
     "ignore": false,
     "images": [
-        "DisplayRouteLayer.jpg"
+        "displayroutelayer.jpg"
     ],
     "keywords": [
         "directions",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayScene/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayScene/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayScene",
     "ignore": false,
     "images": [
-        "DisplayScene.jpg"
+        "displayscene.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplaySubtypeFeatureLayer",
     "ignore": false,
     "images": [
-        "DisplaySubtypeFeatureLayer.jpg"
+        "displaysubtypefeaturelayer.jpg"
     ],
     "keywords": [
         "asset group",

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayWfs",
     "ignore": false,
     "images": [
-        "DisplayWfs.jpg"
+        "displaywfs.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/EditKmlGroundOverlay/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/EditKmlGroundOverlay/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "EditKmlGroundOverlay",
     "ignore": false,
     "images": [
-        "EditKmlGroundOverlay.jpg"
+        "editkmlgroundoverlay.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ExportTiles",
     "ignore": false,
     "images": [
-        "ExportTiles.jpg"
+        "exporttiles.jpg"
     ],
     "keywords": [
         "cache",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ExportVectorTiles",
     "ignore": false,
     "images": [
-        "ExportVectorTiles.jpg"
+        "exportvectortiles.jpg"
     ],
     "keywords": [
         "cache",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureCollectionLayerFromPortal",
     "ignore": false,
     "images": [
-        "FeatureCollectionLayerFromPortal.jpg"
+        "featurecollectionlayerfromportal.jpg"
     ],
     "keywords": [
         "collection",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureCollectionLayerFromQuery",
     "ignore": false,
     "images": [
-        "FeatureCollectionLayerFromQuery.jpg"
+        "featurecollectionlayerfromquery.jpg"
     ],
     "keywords": [
         "layer",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerDefinitionExpression",
     "ignore": false,
     "images": [
-        "FeatureLayerDefinitionExpression.jpg"
+        "featurelayerdefinitionexpression.jpg"
     ],
     "keywords": [
         "SQL",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerDictionaryRenderer",
     "ignore": false,
     "images": [
-        "FeatureLayerDictionaryRenderer.jpg"
+        "featurelayerdictionaryrenderer.jpg"
     ],
     "keywords": [
         "military",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerRenderingModeMap",
     "ignore": false,
     "images": [
-        "FeatureLayerRenderingModeMap.jpg"
+        "featurelayerrenderingmodemap.jpg"
     ],
     "keywords": [
         "dynamic",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeScene/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeScene/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerRenderingModeScene",
     "ignore": false,
     "images": [
-        "FeatureLayerRenderingModeScene.jpg"
+        "featurelayerrenderingmodescene.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerSelection",
     "ignore": false,
     "images": [
-        "FeatureLayerSelection.jpg"
+        "featurelayerselection.jpg"
     ],
     "keywords": [
         "features",

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerUrl/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerUrl/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerUrl",
     "ignore": false,
     "images": [
-        "FeatureLayerUrl.jpg"
+        "featurelayerurl.jpg"
     ],
     "keywords": [
         "feature table",

--- a/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GroupLayers",
     "ignore": false,
     "images": [
-        "GroupLayers.jpg"
+        "grouplayers.jpg"
     ],
     "keywords": [
         "group layer",

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "IdentifyKmlFeatures",
     "ignore": false,
     "images": [
-        "IdentifyKmlFeatures.jpg"
+        "identifykmlfeatures.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "IdentifyRasterCell",
     "ignore": false,
     "images": [
-        "IdentifyRasterCell.jpg"
+        "identifyrastercell.jpg"
     ],
     "keywords": [
         "NDVI",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ListKmlContents",
     "ignore": false,
     "images": [
-        "ListKmlContents.jpg"
+        "listkmlcontents.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/LoadWebTiledLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/LoadWebTiledLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "LoadWebTiledLayer",
     "ignore": false,
     "images": [
-        "LoadWebTiledLayer.jpg"
+        "loadwebtiledlayer.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "MapImageLayerTables",
     "ignore": false,
     "images": [
-        "MapImageLayerTables.jpg"
+        "mapimagelayertables.jpg"
     ],
     "keywords": [
         "features",

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "MapImageSublayerQuery",
     "ignore": false,
     "images": [
-        "MapImageSublayerQuery.jpg"
+        "mapimagesublayerquery.jpg"
     ],
     "keywords": [
         "search and query"

--- a/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OpenStreetMapLayer",
     "ignore": false,
     "images": [
-        "OpenStreetMapLayer.jpg"
+        "openstreetmaplayer.jpg"
     ],
     "keywords": [
         "OSM",

--- a/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "PlayKmlTours",
     "ignore": false,
     "images": [
-        "PlayKmlTours.jpg"
+        "playkmltours.jpg"
     ],
     "keywords": [
         "KML",

--- a/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "QueryCQLFilters",
     "ignore": false,
     "images": [
-        "QueryCQLFilters.jpg"
+        "querycqlfilters.jpg"
     ],
     "keywords": [
         "CQL",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterColormapRenderer",
     "ignore": false,
     "images": [
-        "RasterColormapRenderer.jpg"
+        "rastercolormaprenderer.jpg"
     ],
     "keywords": [
         "colormap",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterHillshade",
     "ignore": false,
     "images": [
-        "RasterHillshade.jpg"
+        "rasterhillshade.jpg"
     ],
     "keywords": [
         "altitude",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterLayerFile",
     "ignore": false,
     "images": [
-        "RasterLayerFile.jpg"
+        "rasterlayerfile.jpg"
     ],
     "keywords": [
         "data",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerImageServiceRaster/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerImageServiceRaster/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterLayerImageServiceRaster",
     "ignore": false,
     "images": [
-        "RasterLayerImageServiceRaster.jpg"
+        "rasterlayerimageserviceraster.jpg"
     ],
     "keywords": [
         "image service",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterLayerRasterFunction",
     "ignore": false,
     "images": [
-        "RasterLayerRasterFunction.jpg"
+        "rasterlayerrasterfunction.jpg"
     ],
     "keywords": [
         "function",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterRenderingRule",
     "ignore": false,
     "images": [
-        "RasterRenderingRule.jpg"
+        "rasterrenderingrule.jpg"
     ],
     "keywords": [
         "raster",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RasterRgbRenderer",
     "ignore": false,
     "images": [
-        "RasterRgbRenderer.jpg"
+        "rasterrgbrenderer.jpg"
     ],
     "keywords": [
         "analysis",

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SceneLayerSelection",
     "ignore": false,
     "images": [
-        "SceneLayerSelection.jpg"
+        "scenelayerselection.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SceneLayerUrl",
     "ignore": false,
     "images": [
-        "SceneLayerUrl.jpg"
+        "scenelayerurl.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ShowLabelsOnLayer",
     "ignore": false,
     "images": [
-        "ShowLabelsOnLayer.jpg"
+        "showlabelsonlayer.jpg"
     ],
     "keywords": [
         "arcade",

--- a/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "StyleWmsLayer",
     "ignore": false,
     "images": [
-        "StyleWmsLayer.jpg"
+        "stylewmslayer.jpg"
     ],
     "keywords": [
         "WMS",

--- a/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "TimeBasedQuery",
     "ignore": false,
     "images": [
-        "TimeBasedQuery.jpg"
+        "timebasedquery.jpg"
     ],
     "keywords": [
         "query",

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMSLayerUrl/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMSLayerUrl/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "WMSLayerUrl",
     "ignore": false,
     "images": [
-        "WMSLayerUrl.jpg"
+        "wmslayerurl.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "WMTSLayer",
     "ignore": false,
     "images": [
-        "WMTSLayer.jpg"
+        "wmtslayer.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "WfsXmlQuery",
     "ignore": false,
     "images": [
-        "WfsXmlQuery.jpg"
+        "wfsxmlquery.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "WmsIdentify",
     "ignore": false,
     "images": [
-        "WmsIdentify.jpg"
+        "wmsidentify.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "WmsServiceCatalog",
     "ignore": false,
     "images": [
-        "WmsServiceCatalog.jpg"
+        "wmsservicecatalog.jpg"
     ],
     "keywords": [
         "OGC",

--- a/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayDeviceLocation",
     "ignore": false,
     "images": [
-        "DisplayDeviceLocation.jpg"
+        "displaydevicelocation.jpg"
     ],
     "keywords": [
         "GPS",

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "IndoorPositioning",
     "ignore": false,
     "images": [
-        "IndoorPositioning.jpg"
+        "indoorpositioning.jpg"
     ],
     "keywords": [
         "BLE",

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "LocationDrivenGeotriggers",
     "ignore": false,
     "images": [
-        "LocationDrivenGeotriggers.jpg"
+        "locationdrivengeotriggers.jpg"
     ],
     "keywords": [
         "alert",

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "LocationWithNMEA",
     "ignore": false,
     "images": [
-        "LocationWithNMEA.jpg"
+        "locationwithnmea.jpg"
     ],
     "keywords": [
         "GNSS",

--- a/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ShowLocationHistory",
     "ignore": false,
     "images": [
-        "ShowLocationHistory.jpg"
+        "showlocationhistory.jpg"
     ],
     "keywords": [
         "GPS",

--- a/src/MAUI/Maui.Samples/Samples/Map/AccessLoadStatus/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/AccessLoadStatus/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AccessLoadStatus",
     "ignore": false,
     "images": [
-        "AccessLoadStatus.jpg"
+        "accessloadstatus.jpg"
     ],
     "keywords": [
         "load status",

--- a/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ApplyScheduledUpdates",
     "ignore": false,
     "images": [
-        "ApplyScheduledUpdates.jpg"
+        "applyscheduledupdates.jpg"
     ],
     "keywords": [
         "offline",

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AuthorMap",
     "ignore": false,
     "images": [
-        "AuthorMap.jpg"
+        "authormap.jpg"
     ],
     "keywords": [
         "ArcGIS Online",

--- a/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "BrowseBuildingFloors",
     "ignore": false,
     "images": [
-        "BrowseBuildingFloors.jpg"
+        "browsebuildingfloors.jpg"
     ],
     "keywords": [
         "building",

--- a/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeBasemap",
     "ignore": false,
     "images": [
-        "ChangeBasemap.jpg"
+        "changebasemap.jpg"
     ],
     "keywords": [
         "basemap",

--- a/src/MAUI/Maui.Samples/Samples/Map/DisplayMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/DisplayMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayMap",
     "ignore": false,
     "images": [
-        "DisplayMap.jpg"
+        "displaymap.jpg"
     ],
     "keywords": [
         "basemap",

--- a/src/MAUI/Maui.Samples/Samples/Map/DisplayOverviewMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/DisplayOverviewMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayOverviewMap",
     "ignore": false,
     "images": [
-        "DisplayOverviewMap.jpg"
+        "displayoverviewmap.jpg"
     ],
     "keywords": [
         "context",

--- a/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DownloadPreplannedMap",
     "ignore": false,
     "images": [
-        "DownloadPreplannedMap.jpg"
+        "downloadpreplannedmap.jpg"
     ],
     "keywords": [
         "map area",

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GenerateOfflineMap",
     "ignore": false,
     "images": [
-        "GenerateOfflineMap.jpg"
+        "generateofflinemap.jpg"
     ],
     "keywords": [
         "download",

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GenerateOfflineMapWithOverrides",
     "ignore": false,
     "images": [
-        "GenerateOfflineMapWithOverrides.jpg"
+        "generateofflinemapwithoverrides.jpg"
     ],
     "keywords": [
         "LOD",

--- a/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "HonorMobileMapPackageExpiration",
     "ignore": false,
     "images": [
-        "HonorMobileMapPackageExpiration.jpg"
+        "honormobilemappackageexpiration.jpg"
     ],
     "keywords": [
         "expiration",

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ManageBookmarks",
     "ignore": false,
     "images": [
-        "ManageBookmarks.jpg"
+        "managebookmarks.jpg"
     ],
     "keywords": [
         "bookmark",

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ManageOperationalLayers",
     "ignore": false,
     "images": [
-        "ManageOperationalLayers.jpg"
+        "manageoperationallayers.jpg"
     ],
     "keywords": [
         "add",

--- a/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "MapReferenceScale",
     "ignore": false,
     "images": [
-        "MapReferenceScale.jpg"
+        "mapreferencescale.jpg"
     ],
     "keywords": [
         "map",

--- a/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "MobileMapSearchAndRoute",
     "ignore": false,
     "images": [
-        "MobileMapSearchAndRoute.jpg"
+        "mobilemapsearchandroute.jpg"
     ],
     "keywords": [
         "disconnected",

--- a/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OfflineBasemapByReference",
     "ignore": false,
     "images": [
-        "OfflineBasemapByReference.jpg"
+        "offlinebasemapbyreference.jpg"
     ],
     "keywords": [
         "basemap",

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OpenMapURL",
     "ignore": false,
     "images": [
-        "OpenMapURL.jpg"
+        "openmapurl.jpg"
     ],
     "keywords": [
         "portal item",

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OpenMobileMap",
     "ignore": false,
     "images": [
-        "OpenMobileMap.jpg"
+        "openmobilemap.jpg"
     ],
     "keywords": [
         "mmpk",

--- a/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SearchPortalMaps",
     "ignore": false,
     "images": [
-        "SearchPortalMaps.jpg"
+        "searchportalmaps.jpg"
     ],
     "keywords": [
         "keyword",

--- a/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapArea/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapArea/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SetInitialMapArea",
     "ignore": false,
     "images": [
-        "SetInitialMapArea.jpg"
+        "setinitialmaparea.jpg"
     ],
     "keywords": [
         "envelope",

--- a/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SetInitialMapLocation",
     "ignore": false,
     "images": [
-        "SetInitialMapLocation.jpg"
+        "setinitialmaplocation.jpg"
     ],
     "keywords": [
         "LOD",

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMapSpatialReference/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMapSpatialReference/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SetMapSpatialReference",
     "ignore": false,
     "images": [
-        "SetMapSpatialReference.jpg"
+        "setmapspatialreference.jpg"
     ],
     "keywords": [
         "WKID",

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SetMaxExtent",
     "ignore": false,
     "images": [
-        "SetMaxExtent.jpg"
+        "setmaxextent.jpg"
     ],
     "keywords": [
         "extent",

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMinMaxScale/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMinMaxScale/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SetMinMaxScale",
     "ignore": false,
     "images": [
-        "SetMinMaxScale.jpg"
+        "setminmaxscale.jpg"
     ],
     "keywords": [
         "area of interest",

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeTimeExtent",
     "ignore": false,
     "images": [
-        "ChangeTimeExtent.jpg"
+        "changetimeextent.jpg"
     ],
     "keywords": [
         "data",

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeViewpoint",
     "ignore": false,
     "images": [
-        "ChangeViewpoint.jpg"
+        "changeviewpoint.jpg"
     ],
     "keywords": [
         "animate",

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayDrawingStatus",
     "ignore": false,
     "images": [
-        "DisplayDrawingStatus.jpg"
+        "displaydrawingstatus.jpg"
     ],
     "keywords": [
         "draw",

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayGrid",
     "ignore": false,
     "images": [
-        "DisplayGrid.jpg"
+        "displaygrid.jpg"
     ],
     "keywords": [
         "MGRS",

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayLayerViewState",
     "ignore": false,
     "images": [
-        "DisplayLayerViewState.jpg"
+        "displaylayerviewstate.jpg"
     ],
     "keywords": [
         "layer",

--- a/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerTimeOffset",
     "ignore": false,
     "images": [
-        "FeatureLayerTimeOffset.jpg"
+        "featurelayertimeoffset.jpg"
     ],
     "keywords": [
         "change",

--- a/src/MAUI/Maui.Samples/Samples/MapView/FilterByTimeExtent/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FilterByTimeExtent/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FilterByTimeExtent",
     "ignore": false,
     "images": [
-        "FilterByTimeExtent.jpg"
+        "filterbytimeextent.jpg"
     ],
     "keywords": [
         "animate",

--- a/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "IdentifyLayers",
     "ignore": false,
     "images": [
-        "IdentifyLayers.jpg"
+        "identifylayers.jpg"
     ],
     "keywords": [
         "identify",

--- a/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "MapRotation",
     "ignore": false,
     "images": [
-        "MapRotation.jpg"
+        "maprotation.jpg"
     ],
     "keywords": [
         "rotate",

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ShowCallout",
     "ignore": false,
     "images": [
-        "ShowCallout.jpg"
+        "showcallout.jpg"
     ],
     "keywords": [
         "balloon",

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ShowMagnifier",
     "ignore": false,
     "images": [
-        "ShowMagnifier.jpg"
+        "showmagnifier.jpg"
     ],
     "keywords": [
         "magnify",

--- a/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "TakeScreenshot",
     "ignore": false,
     "images": [
-        "TakeScreenshot.jpg"
+        "takescreenshot.jpg"
     ],
     "keywords": [
         "capture",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ClosestFacility",
     "ignore": false,
     "images": [
-        "ClosestFacility.jpg"
+        "closestfacility.jpg"
     ],
     "keywords": [
         "incident",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ClosestFacilityStatic",
     "ignore": false,
     "images": [
-        "ClosestFacilityStatic.jpg"
+        "closestfacilitystatic.jpg"
     ],
     "keywords": [
         "incident",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FindRoute",
     "ignore": false,
     "images": [
-        "FindRoute.jpg"
+        "findroute.jpg"
     ],
     "keywords": [
         "directions",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FindServiceArea",
     "ignore": false,
     "images": [
-        "FindServiceArea.jpg"
+        "findservicearea.jpg"
     ],
     "keywords": [
         "barriers",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FindServiceAreasForMultipleFacilities",
     "ignore": false,
     "images": [
-        "FindServiceAreasForMultipleFacilities.jpg"
+        "findserviceareasformultiplefacilities.jpg"
     ],
     "keywords": [
         "facilities",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "NavigateRoute",
     "ignore": false,
     "images": [
-        "NavigateRoute.jpg"
+        "navigateroute.jpg"
     ],
     "keywords": [
         "directions",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "NavigateRouteRerouting",
     "ignore": false,
     "images": [
-        "NavigateRouteRerouting.jpg"
+        "navigateroutererouting.jpg"
     ],
     "keywords": [
         "directions",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OfflineRouting",
     "ignore": false,
     "images": [
-        "OfflineRouting.jpg"
+        "offlinerouting.jpg"
     ],
     "keywords": [
         "connectivity",

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RouteAroundBarriers",
     "ignore": false,
     "images": [
-        "RouteAroundBarriers.jpg"
+        "routearoundbarriers.jpg"
     ],
     "keywords": [
         "barriers",

--- a/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChangeAtmosphereEffect",
     "ignore": false,
     "images": [
-        "ChangeAtmosphereEffect.jpg"
+        "changeatmosphereeffect.jpg"
     ],
     "keywords": [
         "atmosphere",

--- a/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceRaster/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceRaster/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateTerrainSurfaceRaster",
     "ignore": false,
     "images": [
-        "CreateTerrainSurfaceRaster.jpg"
+        "createterrainsurfaceraster.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceTilePackage/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/CreateTerrainSurfaceTilePackage/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CreateTerrainSurfaceTilePackage",
     "ignore": false,
     "images": [
-        "CreateTerrainSurfaceTilePackage.jpg"
+        "createterrainsurfacetilepackage.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GetElevationAtPoint",
     "ignore": false,
     "images": [
-        "GetElevationAtPoint.jpg"
+        "getelevationatpoint.jpg"
     ],
     "keywords": [
         "elevation",

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OpenMobileScenePackage",
     "ignore": false,
     "images": [
-        "OpenMobileScenePackage.jpg"
+        "openmobilescenepackage.jpg"
     ],
     "keywords": [
         "offline",

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OpenScenePortalItem",
     "ignore": false,
     "images": [
-        "OpenScenePortalItem.jpg"
+        "opensceneportalitem.jpg"
     ],
     "keywords": [
         "portal",

--- a/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ShowLabelsOnLayer3D",
     "ignore": false,
     "images": [
-        "ShowLabelsOnLayer3D.jpg"
+        "showlabelsonlayer3d.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "TerrainExaggeration",
     "ignore": false,
     "images": [
-        "TerrainExaggeration.jpg"
+        "terrainexaggeration.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Scene/ViewContentBeneathSurface/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ViewContentBeneathSurface/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ViewContentBeneathSurface",
     "ignore": false,
     "images": [
-        "ViewContentBeneathSurface.jpg"
+        "viewcontentbeneathsurface.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "AnimateImageOverlay",
     "ignore": false,
     "images": [
-        "AnimateImageOverlay.jpg"
+        "animateimageoverlay.jpg"
     ],
     "keywords": [
         "3d",

--- a/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ChooseCameraController",
     "ignore": false,
     "images": [
-        "ChooseCameraController.jpg"
+        "choosecameracontroller.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/SceneView/GeoViewSync/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/GeoViewSync/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "GeoViewSync",
     "ignore": false,
     "images": [
-        "GeoViewSync.jpg"
+        "geoviewsync.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Search/FindAddress/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindAddress/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FindAddress",
     "ignore": false,
     "images": [
-        "FindAddress.jpg"
+        "findaddress.jpg"
     ],
     "keywords": [
         "address",

--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FindPlace",
     "ignore": false,
     "images": [
-        "FindPlace.jpg"
+        "findplace.jpg"
     ],
     "keywords": [
         "POI",

--- a/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OfflineGeocode",
     "ignore": false,
     "images": [
-        "OfflineGeocode.jpg"
+        "offlinegeocode.jpg"
     ],
     "keywords": [
         "geocode",

--- a/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ReverseGeocode",
     "ignore": false,
     "images": [
-        "ReverseGeocode.jpg"
+        "reversegeocode.jpg"
     ],
     "keywords": [
         "address",

--- a/src/MAUI/Maui.Samples/Samples/Security/OAuth/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Security/OAuth/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "OAuth",
     "ignore": false,
     "images": [
-        "OAuth.jpg"
+        "oauth.jpg"
     ],
     "keywords": [
         "OAuth",

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "TokenSecuredChallenge",
     "ignore": false,
     "images": [
-        "TokenSecuredChallenge.jpg"
+        "tokensecuredchallenge.jpg"
     ],
     "keywords": [
         "authentication",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "CustomDictionaryStyle",
     "ignore": false,
     "images": [
-        "CustomDictionaryStyle.jpg"
+        "customdictionarystyle.jpg"
     ],
     "keywords": [
         "ArcGIS Online",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "FeatureLayerExtrusion",
     "ignore": false,
     "images": [
-        "FeatureLayerExtrusion.jpg"
+        "featurelayerextrusion.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderMultilayerSymbols/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderMultilayerSymbols/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RenderMultilayerSymbols",
     "ignore": false,
     "images": [
-        "RenderMultilayerSymbols.jpg"
+        "rendermultilayersymbols.jpg"
     ],
     "keywords": [
         "graphic",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderPictureMarkers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderPictureMarkers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RenderPictureMarkers",
     "ignore": false,
     "images": [
-        "RenderPictureMarkers.jpg"
+        "renderpicturemarkers.jpg"
     ],
     "keywords": [
         "graphics",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderSimpleMarkers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderSimpleMarkers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RenderSimpleMarkers",
     "ignore": false,
     "images": [
-        "RenderSimpleMarkers.jpg"
+        "rendersimplemarkers.jpg"
     ],
     "keywords": [
         "symbol"

--- a/src/MAUI/Maui.Samples/Samples/Symbology/RenderUniqueValues/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/RenderUniqueValues/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "RenderUniqueValues",
     "ignore": false,
     "images": [
-        "RenderUniqueValues.jpg"
+        "renderuniquevalues.jpg"
     ],
     "keywords": [
         "draw",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SceneSymbols/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SceneSymbols/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SceneSymbols",
     "ignore": false,
     "images": [
-        "SceneSymbols.jpg"
+        "scenesymbols.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SimpleRenderers/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SimpleRenderers/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SimpleRenderers",
     "ignore": false,
     "images": [
-        "SimpleRenderers.jpg"
+        "simplerenderers.jpg"
     ],
     "keywords": [
         "graphics",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SymbolStylesFromWebStyles",
     "ignore": false,
     "images": [
-        "SymbolStylesFromWebStyles.jpg"
+        "symbolstylesfromwebstyles.jpg"
     ],
     "keywords": [
         "renderer",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "SymbolsFromMobileStyle",
     "ignore": false,
     "images": [
-        "SymbolsFromMobileStyle.jpg"
+        "symbolsfrommobilestyle.jpg"
     ],
     "keywords": [
         "advanced symbology",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "UniqueValuesAlternateSymbols",
     "ignore": false,
     "images": [
-        "UniqueValuesAlternateSymbols.jpg"
+        "uniquevaluesalternatesymbols.jpg"
     ],
     "keywords": [
         "alternate symbols",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/UseDistanceCompositeSym/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/UseDistanceCompositeSym/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "UseDistanceCompositeSym",
     "ignore": false,
     "images": [
-        "UseDistanceCompositeSym.jpg"
+        "usedistancecompositesym.jpg"
     ],
     "keywords": [
         "3D",

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "ConfigureSubnetworkTrace",
     "ignore": false,
     "images": [
-        "ConfigureSubnetworkTrace.jpg"
+        "configuresubnetworktrace.jpg"
     ],
     "keywords": [
         "category comparison",

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayUtilityAssociations",
     "ignore": false,
     "images": [
-        "DisplayUtilityAssociations.jpg"
+        "displayutilityassociations.jpg"
     ],
     "keywords": [
         "associating",

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "DisplayUtilityNetworkContainer",
     "ignore": false,
     "images": [
-        "DisplayUtilityNetworkContainer.jpg"
+        "displayutilitynetworkcontainer.jpg"
     ],
     "keywords": [
         "associations",

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "PerformValveIsolationTrace",
     "ignore": false,
     "images": [
-        "PerformValveIsolationTrace.jpg"
+        "performvalveisolationtrace.jpg"
     ],
     "keywords": [
         "category comparison",

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/readme.metadata.json
@@ -4,7 +4,7 @@
     "formal_name": "TraceUtilityNetwork",
     "ignore": false,
     "images": [
-        "TraceUtilityNetwork.jpg"
+        "traceutilitynetwork.jpg"
     ],
     "keywords": [
         "condition barriers",


### PR DESCRIPTION
# Description

Fixes MAUI metadata files to utilize lowercase image names.

## Type of change

- Other enhancement

## Platforms tested on

- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
