### PR TITLE
WinUI disable favoriting properties

### DIFF
--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -60,8 +60,9 @@ namespace ArcGIS.Samples.Shared.Models
 
         public string Instructions { get; set; }
 
-        public bool IsFavorite { get; set; }
 
+#if (!WinUI)
+        public bool IsFavorite { get; set; }
 
         public bool ShowFavoriteIcon
         {
@@ -78,6 +79,7 @@ namespace ArcGIS.Samples.Shared.Models
                 return isMobile || SampleManager.Current.IsSampleFavorited(FormalName);
             }
         }
+#endif
 
         /// <summary>
         /// A list of offline data items that should be downloaded


### PR DESCRIPTION
# Description

Sample viewer is not deploying currently; this PR addresses the error.  Favoriting properties shouldn't be enabled - the problem was conditional compilation disabled `SampleManager.Current.IsSampleFavorited(FormalName)`for WinUI but this was being called in the `ShowFavoriteIcon` property.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
