### PR TITLE
Fix incorrect tabs showing in WPF Sample Viewer 

### DIFF
--- a/src/WPF/WPF.Viewer/SourceCodeViewer.xaml.cs
+++ b/src/WPF/WPF.Viewer/SourceCodeViewer.xaml.cs
@@ -63,9 +63,22 @@ namespace ArcGIS.WPF.Viewer
             // Add additional class files from the sample.
             if (SampleManager.Current.SelectedSample.ClassFiles != null)
             {
-                foreach (string additionalPath in SampleManager.Current.SelectedSample.ClassFiles)
+                try
                 {
-                    SourceFiles.Insert(0, new SourceCodeFile(additionalPath));
+                    var folderName = folderPath.Split("//").Last();
+
+                    foreach (string additionalPath in SampleManager.Current.SelectedSample.ClassFiles)
+                    {
+                        var additionalPathArray = additionalPath.Split("//");
+
+                        if (folderName != additionalPathArray[additionalPathArray.Length - 1]) continue;
+
+                        SourceFiles.Insert(0, new SourceCodeFile(additionalPath));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // do nothing
                 }
             }
 


### PR DESCRIPTION
# Description

The WPF Sample Viewer was incorrectly showing files in the `Source Code` tab for some samples. This fix should address this issue. 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
