### PR TITLE
Fix WPF .NET Framework build

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGIS.WPF.Samples.StatisticalQuery
         // World cities feature table.
         private FeatureTable _worldCitiesTable;
 
-        private readonly Dictionary<string, string> _statisticNames = new()
+        private readonly Dictionary<string, string> _statisticNames = new Dictionary<string, string>
         {
             {"AVG_POP","Average Population"},
             {"CityCount","City Count"},


### PR DESCRIPTION
# Description

The build was broken by a related change to the WPF .NET 6.0 build.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
