### PR TITLE
WPF replace target type object creation

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGIS.WPF.Samples.StatisticalQuery
         // World cities feature table.
         private FeatureTable _worldCitiesTable;
 
-        private readonly Dictionary<string, string> _statisticNames = new()
+        private readonly Dictionary<string, string> _statisticNames = new Dictionary<string, string>()
         {
             {"AVG_POP","Average Population"},
             {"CityCount","City Count"},


### PR DESCRIPTION
# Description

Target type object creation unavailable in C# 7.2, so .NET Framework viewer wasn't deploying. So, instantiate the object per normal convention.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [x] WPF Framework

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
