### PR TITLE
[MAUI] Fixed issue that caused the API key to be dropped

### DIFF
--- a/src/MAUI/Maui.Samples/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/CategoryPage.xaml.cs
@@ -1,5 +1,6 @@
 using ArcGIS.Helpers;
 using ArcGIS.Samples.Managers;
+using ArcGIS.Samples.Shared.Managers;
 using ArcGIS.Samples.Shared.Models;
 using ArcGIS.ViewModels;
 using CommunityToolkit.Maui.Views;
@@ -90,6 +91,16 @@ public partial class CategoryPage : ContentPage
         }
 
         SetBindingContext();
-        
+    }
+
+    protected override void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+
+        // Ensure we enable the API key when we navigate here at any time. 
+        if (ApiKeyManager.KeyDisabled)
+        {
+            ApiKeyManager.EnableKey();
+        }
     }
 }

--- a/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
+++ b/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
@@ -29,16 +29,15 @@ namespace ArcGIS.Helpers
                 // Set the currently selected sample.
                 SampleManager.Current.SelectedSample = sampleInfo;
 
-                // Restore API key if leaving named user sample.
-                if (_namedUserSamples.Contains(SampleManager.Current?.SelectedSample?.FormalName))
-                {
-                    ApiKeyManager.EnableKey();
-                }
-
                 // Remove API key if opening named user sample.
                 if (_namedUserSamples.Contains(sampleInfo.FormalName))
                 {
                     ApiKeyManager.DisableKey();
+                }
+                else
+                {
+                    // Ensure the API key is enabled if the sample that is being opened is not a named user sample.
+                    ApiKeyManager.EnableKey();
                 }
 
                 // Clear any existing credentials from AuthenticationManager.

--- a/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
@@ -7,7 +7,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using ArcGIS.Samples.Shared.Managers;
 using ArcGIS.Helpers;
 using Esri.ArcGISRuntime;
 using Esri.ArcGISRuntime.Mapping;
@@ -169,12 +168,6 @@ namespace ArcGIS.Samples.SearchPortalMaps
         private void ListCloseClicked(object sender, EventArgs e)
         {
             MapsListBorder.IsVisible = false;
-        }
-
-        public void Dispose()
-        {
-            // Re-enable the API key in the viewer when exiting this sample.
-            ApiKeyManager.EnableKey();
         }
     }
 }

--- a/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
@@ -7,7 +7,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using ArcGIS.Samples.Shared.Managers;
 using ArcGIS.Helpers;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Portal;
@@ -21,7 +20,7 @@ namespace ArcGIS.Samples.OAuth
         instructions: "When you run the sample, the app will load a web map which contains premium content. You will be challenged for an ArcGIS Online login to view the private layers. Enter a user name and password for an ArcGIS Online named user account (such as your ArcGIS for Developers account). If you authenticate successfully, the traffic layer will display, otherwise the map will contain only the public basemap layer.",
         tags: new[] { "OAuth", "OAuth2", "authentication", "cloud", "credential", "portal", "security" })]
     [ArcGIS.Samples.Shared.Attributes.ClassFile("Helpers/ArcGISLoginPrompt.cs")]
-    public partial class OAuth : ContentPage, IDisposable
+    public partial class OAuth : ContentPage
     {
         // - The URL of the portal to authenticate with
         private const string ServerUrl = "https://www.arcgis.com/sharing/rest";
@@ -60,12 +59,6 @@ namespace ArcGIS.Samples.OAuth
             {
                 await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
-        }
-
-        public void Dispose()
-        {
-            // Re-enable the API key in the viewer when exiting this sample.
-            ApiKeyManager.EnableKey();
         }
     }
 }

--- a/src/Samples.Shared/Managers/ApiKeyManager.cs
+++ b/src/Samples.Shared/Managers/ApiKeyManager.cs
@@ -34,6 +34,8 @@ namespace ArcGIS.Samples.Shared.Managers
         private static string _key;
         private static bool _keyDisabled;
 
+        public static bool KeyDisabled { get { return _keyDisabled; } }
+
         // Name for file on windows systems. / Name for key in .NET MAUI SecureStorage.
         private const string _apiKeyFileName = "agolResource";
 


### PR DESCRIPTION
# Description

Some samples require the API key to be dropped in order for them to function due to differing authentication methods. This PR fixes an issue which caused the PR to remain unset when it should have been set again.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
