### PR TITLE
winui: Add WindowsPackageType=None to unpackaged project

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
@@ -11,6 +11,7 @@
     <ArcGISLocalServerIgnoreMissingComponent>True</ArcGISLocalServerIgnoreMissingComponent>
     <OutputPath>..\..\..\output\WinUI\$(Configuration)\$(Platform)\</OutputPath>
     <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <DefineConstants>WinUI</DefineConstants>


### PR DESCRIPTION
# Description
Adds `<WindowsPackageType>None</WindowsPackageType>` to our _non-packaged_ WinUI project.  This is recommended by Microsoft ([here](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app?pivots=winui3-unpackaged-csharp#the-bootstrapper-api) and [here](https://github.com/microsoft/WindowsAppSDK/issues/1762#issuecomment-1017415180)).  The effect of this change is:

When a user doesn't have the exact right version of Windows Apps Runtime installed, they will now get a helpful prompt like this (clicking "Yes" opens the [download page](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads)):

<img width="298" alt="2023-06-21_174446 ArcGIS WinUI Viewer" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/587809/c0e10933-d7bb-44e1-9611-8293c1a686e0">


...instead of silently crashing like this:

```
Exception thrown: 'System.DllNotFoundException' in ArcGIS.WinUI.Viewer.dll
An unhandled exception of type 'System.DllNotFoundException' occurred in ArcGIS.WinUI.Viewer.dll
Unable to load DLL 'Microsoft.ui.xaml.dll' or one of its dependencies: The specified module could not be found. (0x8007007E)
The program '[8968] ArcGIS.WinUI.Viewer.exe' has exited with code 0 (0x0).
```

The packaged project is not affected.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
