### PR TITLE
Skip popping the load data dialog if data is already there

### DIFF
--- a/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
+++ b/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
@@ -50,7 +50,7 @@ namespace ArcGIS.Helpers
                 AuthenticationManager.Current.ChallengeHandler = null;
 
                 // Load offline data before showing the sample.
-                if (sampleInfo.OfflineDataItems != null)
+                if (sampleInfo.OfflineDataItems != null && !await DataManager.HasSampleDataPresent(sampleInfo))
                 {
                     CancellationTokenSource cancellationSource = new CancellationTokenSource();
 

--- a/src/Samples.Shared/Managers/DataManager.cs
+++ b/src/Samples.Shared/Managers/DataManager.cs
@@ -122,6 +122,17 @@ namespace ArcGIS.Samples.Managers
             return EnsureSampleDataPresent(sample.OfflineDataItems, token, onProgress);
         }
 
+        public static async Task<bool> HasSampleDataPresent(SampleInfo info)
+        {
+            if (info.OfflineDataItems is null) return true;
+            foreach (string itemId in info.OfflineDataItems)
+            {
+                bool isDownloaded = await IsDataPresent(itemId);
+                if (!isDownloaded) return false;
+            }
+            return true;
+        }
+
         public static async Task EnsureSampleDataPresent(IEnumerable<string> itemIds, CancellationToken token, Action<ProgressInfo> onProgress = null)
         {
             // Return if there's nothing to do.


### PR DESCRIPTION

# Description

This results in a much faster loading experience on subsequent runs.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
