### PR TITLE
Explicit cleanup upon closing samples

### DIFF
--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -254,7 +254,7 @@ namespace ArcGIS.Samples.Desktop
                 {
                     for (int i = 0; i < VisualTreeHelper.GetChildrenCount(it); i++)
                     {
-                        var e = VisualTreeHelper.GetChild(it, 0);
+                        var e = VisualTreeHelper.GetChild(it, i);
                         foreach (var obj in TreeWalker<T>(e as UIElement))
                             yield return obj;
                     }

--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -246,7 +246,7 @@ namespace ArcGIS.Samples.Desktop
 
         private static IEnumerable<T> TreeWalker<T>(UIElement root)
         {
-            if (root is not null)
+            if (root != null)
             {
                 if (root is T t)
                     yield return t;

--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using ArcGIS.Samples.Managers;
 using ArcGIS.Samples.Shared.Managers;
 using ArcGIS.Samples.Shared.Models;
 using Esri.ArcGISRuntime.Security;
+using Esri.ArcGISRuntime.UI.Controls;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -205,6 +206,7 @@ namespace ArcGIS.Samples.Desktop
 
                 // Show the sample
                 SampleContainer.Content = SampleManager.Current.SampleToControl(selectedSample);
+                (SampleContainer.Content as FrameworkElement).Unloaded += Sample_Unloaded;
                 SourceCodeContainer.LoadSourceCode();
 
                 // Set the color of the favorite button
@@ -225,6 +227,39 @@ namespace ArcGIS.Samples.Desktop
 
             SetScreenshotButttonVisibility();
             SetContainerDimensions();
+        }
+
+        private static void Sample_Unloaded(object sender, RoutedEventArgs e)
+        {
+            // Explicit cleanup of the Map and SceneView instead of waiting for garbage collector can help when
+            // lots of geoviews are being opened and closed
+            foreach (var geoView in TreeWalker<GeoView>(sender as UIElement))
+            {
+                if (geoView is MapView mapView)
+                {
+                    mapView.Map = null;
+                    if (mapView.LocationDisplay != null) mapView.LocationDisplay.IsEnabled = false;
+                }
+                else if (geoView is SceneView sceneView) sceneView.Scene = null;
+            }
+        }
+
+        private static IEnumerable<T> TreeWalker<T>(UIElement root)
+        {
+            if (root is not null)
+            {
+                if (root is T t)
+                    yield return t;
+                else if (root is UIElement it)
+                {
+                    for (int i = 0; i < VisualTreeHelper.GetChildrenCount(it); i++)
+                    {
+                        var e = VisualTreeHelper.GetChild(it, 0);
+                        foreach (var obj in TreeWalker<T>(e as UIElement))
+                            yield return obj;
+                    }
+                }
+            }
         }
 
         private static void ClearCredentials()

--- a/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
@@ -39,8 +39,6 @@ namespace ArcGIS.WinUI.Viewer
             // Load and show the sample.
             SampleContainer.Content = SampleManager.Current.SampleToControl(SampleManager.Current.SelectedSample);
 
-            (SampleContainer.Content as FrameworkElement).Unloaded += SamplePage_Unloaded;
-
             if (ScreenshotManager.ScreenshotSettings.ScreenshotEnabled)
             {
                 KeyDown += ScreenshotKeyDown_Event;
@@ -94,7 +92,7 @@ namespace ArcGIS.WinUI.Viewer
 
             // Explicit cleanup of the Map and SceneView instead of waiting for garbage collector can help when
             // lots of geoviews are being opened and closed
-            foreach (var geoView in TreeWalker<GeoView>(sender as UIElement))
+            foreach (var geoView in TreeWalker<GeoView>(SampleContainer.Content as UIElement))
             {
                 if (geoView is MapView mapView)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
@@ -113,7 +113,7 @@ namespace ArcGIS.WinUI.Viewer
                 {
                     for (int i = 0; i < VisualTreeHelper.GetChildrenCount(it); i++)
                     {
-                        var e = VisualTreeHelper.GetChild(it, 0);
+                        var e = VisualTreeHelper.GetChild(it, i);
                         foreach (var obj in TreeWalker<T>(e as UIElement))
                             yield return obj;
                     }


### PR DESCRIPTION
# Description

- Ensures location services are disabled
- Nullifies maps and scenes
- Removes life cycle workaround for iOS/MacCatalyst - event works fine now

## Type of change

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
