### PR TITLE
Windows: webview memleak

### DIFF
--- a/src/MAUI/Maui.Samples/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml
@@ -19,7 +19,6 @@
     </ContentPage.ToolbarItems>
     <Grid>
         <Border x:Name="SampleDetailPage" IsVisible="false">
-            <WebView x:Name="DescriptionView" />
         </Border>
         <Border x:Name="SourceCodePage" IsVisible="false">
             <StackLayout>
@@ -34,7 +33,7 @@
                         Text=""
                         VerticalOptions="Center" />
                 </StackLayout>
-                <WebView x:Name="SourceCodeView" VerticalOptions="FillAndExpand" />
+                <Border x:Name="SourceCodeViewContainer" VerticalOptions="FillAndExpand" />
             </StackLayout>
         </Border>
         <Border

--- a/src/MAUI/Maui.Samples/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml.cs
@@ -31,6 +31,9 @@ namespace ArcGIS
         private ContentPage _sample;
         private Assembly _assembly;
         private int _lastViewedFileIndex = 0;
+        // single-instance webviews reused on each view, to avoid a memory leak in webview
+        static WebView DescriptionView = new WebView();
+        static WebView SourceCodeView = new WebView();
 
         public ObservableCollection<SourceCodeFile> SourceFiles { get; } = new ObservableCollection<SourceCodeFile>();
 
@@ -83,6 +86,22 @@ namespace ArcGIS
             LoadSampleData(sampleInfo);
         }
 
+        protected override void OnNavigatedTo(NavigatedToEventArgs args)
+        {
+            base.OnNavigatedTo(args);
+            SampleDetailPage.Content = DescriptionView;
+            SourceCodeViewContainer.Content = SourceCodeView;
+            DescriptionView.Navigating += Webview_Navigating;
+            SourceCodeView.Navigating += Webview_Navigating;
+        }
+        protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+        {
+            SampleDetailPage.Content = null;
+            SourceCodeViewContainer.Content = null;
+            DescriptionView.Navigating -= Webview_Navigating;
+            SourceCodeView.Navigating -= Webview_Navigating;
+            base.OnNavigatingFrom(args);
+        }
         private async void LoadSampleData(SampleInfo sampleInfo)
         { 
             // Set up the description page.
@@ -93,7 +112,6 @@ namespace ArcGIS
                 {
                     Html = htmlString
                 };
-                DescriptionView.Navigating += Webview_Navigating;
             }
             catch (Exception ex)
             {
@@ -104,7 +122,6 @@ namespace ArcGIS
             {
                 LoadSourceCode(sampleInfo);
 
-                SourceCodeView.Navigating += Webview_Navigating;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Description

Matvei confirmed my finding that it was the webviews causing the the entire page to stay resident and that this fix addresses the Windows memory leak.
Haven't had a chance to check if this workaround is good on ios and android, but my guess is it can't hurt too much.

![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/1378165/cfef81e3-e757-4109-bc42-f733a876a39f)

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
