### PR TITLE
Play KML tours SceneViewInteractionOptions

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -10,6 +10,7 @@
 using ArcGIS.Samples.Managers;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Ogc;
+using Esri.ArcGISRuntime.UI;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -75,6 +76,12 @@ namespace ArcGIS.Samples.PlayKmlTours
 
                 // Hide the status bar.
                 LoadingStatusBar.IsVisible = false;
+
+                // Create scene interaction options which will be disabled when the tour begins.
+                MySceneView.InteractionOptions = new SceneViewInteractionOptions
+                {
+                    IsEnabled = false
+                };
             }
             catch (Exception e)
             {
@@ -136,6 +143,7 @@ namespace ArcGIS.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Text = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
 
                     // Return to the initial viewpoint to visually indicate the tour being over.
                     MySceneView.SetViewpointAsync(MySceneView.Scene.InitialViewpoint);
@@ -146,6 +154,7 @@ namespace ArcGIS.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Text = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
                     break;
 
                 case KmlTourStatus.Playing:
@@ -153,6 +162,7 @@ namespace ArcGIS.Samples.PlayKmlTours
                     PlayPauseButton.IsEnabled = true;
                     PlayPauseButton.Text = "Pause";
                     _tourPlaying = true;
+                    MySceneView.InteractionOptions.IsEnabled = false;
                     break;
 
                 case KmlTourStatus.Paused:

--- a/src/WPF/WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -10,6 +10,7 @@
 using ArcGIS.Samples.Managers;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Ogc;
+using Esri.ArcGISRuntime.UI;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -84,6 +85,12 @@ namespace ArcGIS.WPF.Samples.PlayKmlTours
 
                 // Hide the status bar.
                 LoadingStatusBar.Visibility = Visibility.Collapsed;
+
+                // Create scene interaction options which will be disabled when the tour begins.
+                MySceneView.InteractionOptions = new SceneViewInteractionOptions
+                {
+                    IsEnabled = false
+                };
             }
             catch (Exception e)
             {
@@ -145,6 +152,7 @@ namespace ArcGIS.WPF.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Content = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
 
                     // Return to the initial viewpoint to visually indicate the tour being over.
                     MySceneView.SetViewpointAsync(MySceneView.Scene.InitialViewpoint);
@@ -155,12 +163,14 @@ namespace ArcGIS.WPF.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Content = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
                     break;
 
                 case KmlTourStatus.Playing:
                     ResetButton.IsEnabled = true;
                     PlayPauseButton.Content = "Pause";
                     _tourPlaying = true;
+                    MySceneView.InteractionOptions.IsEnabled = false;
                     break;
 
                 case KmlTourStatus.Paused:
@@ -173,7 +183,7 @@ namespace ArcGIS.WPF.Samples.PlayKmlTours
         // Play and pause the tour when the button is pressed.
         private void PlayPause_Click(object sender, RoutedEventArgs e)
         {
-            if(_tourPlaying)
+            if (_tourPlaying)
             {
                 _tourController?.Pause();
             }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -10,6 +10,7 @@
 using ArcGIS.Samples.Managers;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Ogc;
+using Esri.ArcGISRuntime.UI;
 using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
@@ -83,6 +84,12 @@ namespace ArcGIS.WinUI.Samples.PlayKmlTours
 
                 // Hide the status bar.
                 LoadingStatusBar.Visibility = Visibility.Collapsed;
+
+                // Create scene interaction options which will be disabled when the tour begins.
+                MySceneView.InteractionOptions = new SceneViewInteractionOptions
+                {
+                    IsEnabled = false
+                };
             }
             catch (Exception e)
             {
@@ -144,6 +151,7 @@ namespace ArcGIS.WinUI.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Content = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
 
                     // Return to the initial viewpoint to visually indicate the tour being over.
                     MySceneView.SetViewpointAsync(MySceneView.Scene.InitialViewpoint);
@@ -154,12 +162,14 @@ namespace ArcGIS.WinUI.Samples.PlayKmlTours
                     ResetButton.IsEnabled = false;
                     PlayPauseButton.Content = "Play";
                     _tourPlaying = false;
+                    MySceneView.InteractionOptions.IsEnabled = true;
                     break;
 
                 case KmlTourStatus.Playing:
                     ResetButton.IsEnabled = true;
                     PlayPauseButton.Content = "Pause";
                     _tourPlaying = true;
+                    MySceneView.InteractionOptions.IsEnabled = false;
                     break;
 
                 case KmlTourStatus.Paused:


### PR DESCRIPTION
# Description

Updates sample to accommodate new design. Disables `SceneViewInteractionOptions` to make tour a more linear experience. Re-enables when tour is over.

## Type of change

- Other enhancement

## Platforms tested on

- [x] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
