### PR TITLE
Central Package Management

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,8 @@
     <PackageVersion Include="Esri.ArcGISRuntime.WinUI" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Hydrography" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
+    <PackageVersion Include="Esri.ArcGISRuntime.UWP" Version="200.0.0" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.UWP" Version="200.0.0" />
     <PackageVersion Include="Markdig" Version="0.30.4" />
     <PackageVersion Include="System.Text.Json" Version="7.0.1" />
     <PackageVersion Include="System.Speech" Version="7.0.0" />
@@ -25,5 +27,9 @@
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221116.1" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="'$(UseMaui)'!='true'" />
+    <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13"/>
+    <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1"/>
+    <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0"/>
+    <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha"/>
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,24 +5,24 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Esri.ArcGISRuntime" Version="$(ArcGISMapsSDKVersion)" />
-	<PackageVersion Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.WPF" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Maui" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.Maui" Version="$(ArcGISMapsSDKVersion)" />
-	<PackageVersion Include="Esri.ArcGISRuntime.WinUI" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.WinUI" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Hydrography" Version="$(ArcGISMapsSDKVersion)" />
-	<PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-	<PackageVersion Include="Markdig" Version="0.30.4" />
-	<PackageVersion Include="System.Text.Json" Version="7.0.1" />
+    <PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
+    <PackageVersion Include="Markdig" Version="0.30.4" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.1" />
     <PackageVersion Include="System.Speech" Version="7.0.0" />
-	<PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
-	<PackageVersion Include="CommunityToolkit.Maui" Version="5.0.0" />
+    <PackageVersion Include="CommunityToolkit.Maui" Version="5.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-	<PackageVersion Include="WinUIEx" Version="1.8.0" />
+    <PackageVersion Include="WinUIEx" Version="1.8.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
-	<PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,8 @@
     <PackageVersion Include="CommunityToolkit.Maui" Version="5.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.1.0" />
     <PackageVersion Include="WinUIEx" Version="1.8.0" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221116.1" Condition="'$(UseMaui)'!='true'" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="'$(UseMaui)'!='true'" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <ArcGISMapsSDKVersion>200.2.0</ArcGISMapsSDKVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Esri.ArcGISRuntime" Version="$(ArcGISMapsSDKVersion)" />
+	<PackageVersion Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.WPF" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Maui" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.Maui" Version="$(ArcGISMapsSDKVersion)" />
+	<PackageVersion Include="Esri.ArcGISRuntime.WinUI" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Hydrography" Version="$(ArcGISMapsSDKVersion)" />
+	<PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
+	<PackageVersion Include="Markdig" Version="0.30.4" />
+	<PackageVersion Include="System.Text.Json" Version="7.0.1" />
+    <PackageVersion Include="System.Speech" Version="7.0.0" />
+	<PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
+    <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
+    <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
+	<PackageVersion Include="CommunityToolkit.Maui" Version="5.0.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.1.0" />
+	<PackageVersion Include="WinUIEx" Version="1.8.0" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
+	<PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
+  </ItemGroup>
+</Project>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -128,24 +128,22 @@
     </MauiAsset>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="CommunityToolkit.Maui" Version="5.0.0" />
-      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-      <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
-      <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.2.0-daily*" />
-      <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" Version="200.2.0-daily*" />
-      <PackageReference Include="Markdig" Version="0.30.4" />
-      <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+      <PackageReference Include="CommunityToolkit.Maui" />
+      <PackageReference Include="CommunityToolkit.Mvvm" />
+      <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+      <PackageReference Include="Esri.ArcGISRuntime.Maui" />
+      <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" />
+      <PackageReference Include="Markdig" />
+      <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-windows10.0.19041.0'">
-    <PackageReference Include="WinUIEx" Version="1.8.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
+    <PackageReference Include="WinUIEx" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
-    <PackageReference Include="Xamarin.AndroidX.AppCompat">
-      <Version>1.5.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ApiKeyView.xaml.cs">

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -128,13 +128,13 @@
     </MauiAsset>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="CommunityToolkit.Maui" />
-      <PackageReference Include="CommunityToolkit.Mvvm" />
-      <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
-      <PackageReference Include="Esri.ArcGISRuntime.Maui" />
-      <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" />
-      <PackageReference Include="Markdig" />
-      <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="CommunityToolkit.Maui" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+    <PackageReference Include="Esri.ArcGISRuntime.Maui" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" />
+    <PackageReference Include="Markdig" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -130,9 +130,9 @@
   <ItemGroup>
       <PackageReference Include="CommunityToolkit.Maui" Version="5.0.0" />
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-      <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0" />
-      <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.2.0" />
-      <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" Version="200.2.0" />
+      <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
+      <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.2.0-daily*" />
+      <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" Version="200.2.0-daily*" />
       <PackageReference Include="Markdig" Version="0.30.4" />
       <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>

--- a/src/UWP/ArcGIS.UWP.Viewer/ArcGIS.UWP.Viewer.csproj
+++ b/src/UWP/ArcGIS.UWP.Viewer/ArcGIS.UWP.Viewer.csproj
@@ -1852,15 +1852,15 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.0.0"/>
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.UWP" Version="200.0.0"/>
-    <PackageReference Include="Esri.ArcGISRuntime.UWP" Version="200.0.0"/>
-    <PackageReference Include="Markdig" Version="0.30.2"/>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13"/>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1"/>
-    <PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0"/>
-    <PackageReference Include="Monaco.Editor" Version="0.8.1-alpha"/>
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0"/>
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.UWP" />
+    <PackageReference Include="Esri.ArcGISRuntime.UWP" />
+    <PackageReference Include="Markdig" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" />
+    <PackageReference Include="Microsoft.UI.Xaml" />
+    <PackageReference Include="Monaco.Editor" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
   <!-- Source Code Viewer -->
   <ItemGroup>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -60,12 +60,12 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0-daily*" />
-    <PackageReference Include="Markdig" Version="0.30.4" />
-    <PackageReference Include="System.Speech" Version="7.0.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" />
+    <PackageReference Include="Markdig" />
+	<PackageReference Include="System.Speech" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Converters\*.cs">

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" />
     <PackageReference Include="Esri.ArcGISRuntime.WPF" />
     <PackageReference Include="Markdig" />
-	<PackageReference Include="System.Speech" />
+    <PackageReference Include="System.Speech" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Converters\*.cs">

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -60,10 +60,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0-daily*" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0-daily*" />
     <PackageReference Include="Markdig" Version="0.30.4" />
     <PackageReference Include="System.Speech" Version="7.0.0" />
   </ItemGroup>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -282,14 +282,12 @@
   </ItemGroup>
   <!-- Packages -->
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0-daily*" />
-    <PackageReference Include="Markdig" Version="0.30.2" />
-    <PackageReference Include="System.Text.Json">
-      <Version>7.0.1</Version>
-    </PackageReference>
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" />
+    <PackageReference Include="System.Text.Json"/>
+	<PackageReference Include="Markdig" VersionOverride="0.30.2"/>
   </ItemGroup>
   <!-- Imports -->
   <Import Project="..\..\Samples.Shared\ArcGIS.Samples.Shared.projitems" Label="Shared" />

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -287,7 +287,7 @@
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" />
     <PackageReference Include="Esri.ArcGISRuntime.WPF" />
     <PackageReference Include="System.Text.Json"/>
-	<PackageReference Include="Markdig" VersionOverride="0.30.2"/>
+    <PackageReference Include="Markdig" VersionOverride="0.30.2"/>
   </ItemGroup>
   <!-- Imports -->
   <Import Project="..\..\Samples.Shared\ArcGIS.Samples.Shared.projitems" Label="Shared" />

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -282,10 +282,10 @@
   </ItemGroup>
   <!-- Packages -->
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.2.0-daily*" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.2.0-daily*" />
     <PackageReference Include="Markdig" Version="0.30.2" />
     <PackageReference Include="System.Text.Json">
       <Version>7.0.1</Version>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -286,8 +286,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices" />
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" />
     <PackageReference Include="Esri.ArcGISRuntime.WPF" />
-    <PackageReference Include="System.Text.Json"/>
-    <PackageReference Include="Markdig" VersionOverride="0.30.2"/>
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Markdig" />
   </ItemGroup>
   <!-- Imports -->
   <Import Project="..\..\Samples.Shared\ArcGIS.Samples.Shared.projitems" Label="Shared" />

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -58,8 +58,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.WinUI" Version="200.2.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
+    <PackageReference Include="Esri.ArcGISRuntime.WinUI" Version="200.2.0-daily*" />
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -58,15 +58,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.WinUI" Version="200.2.0-daily*" />
-    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221116.1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" />
+    <PackageReference Include="Esri.ArcGISRuntime.WinUI" />
+    <PackageReference Include="Esri.ArcGISRuntime.LocalServices" />
+    <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
@@ -77,10 +77,6 @@
     <Compile Update="Helpers\ArcGISLoginPrompt.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Samples\GraphicsOverlay\SketchOnMap\resources\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Runtime package references should be using the latest daily build in our development branch. This will be accomplished through central package management, so only one place needs to be updated with our daily build.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
