### PR TITLE
Remove EsriSampleContainer style from .NET MAUI samples

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5">

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:sampleViewer="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <VerticalStackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:sampleViewer="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/ViewshedLocation.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedLocation/ViewshedLocation.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnSpacing="5"

--- a/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}" WidthRequest="{OnIdiom Default=-1}">
             <Grid RowDefinitions="auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="GeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid>

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="MapView_Tapped"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="MyMapView_GeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowSpacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowSpacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MaximumWidthRequest="300" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid>

--- a/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5">

--- a/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <VerticalStackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid>

--- a/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Grid.Row="1">

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="400" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/BufferList.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/BufferList/BufferList.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}" WidthRequest="{OnIdiom Phone=-1, Desktop=350, Tablet=350}">
             <Grid Padding="5" RowDefinitions="auto,auto,auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="40,40,40" RowSpacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:sampleViewer="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="400" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="*,*"

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml
@@ -9,7 +9,7 @@
             <local:TransformRowTemplateSelector x:Key="TransformTemplateSelector" />
         </ResourceDictionary>
     </ContentPage.Resources>
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/SpatialOperations.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialOperations/SpatialOperations.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="350" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <ActivityIndicator x:Name="MyActivityIndicator"
                            Grid.RowSpan="2"

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView"
                           AtmosphereEffect="Realistic"
                           Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.xaml
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="auto,*"

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.xaml
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border x:Name="MainUI"
                 Style="{DynamicResource EsriSampleControlPanel}"

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esri="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esri:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}" WidthRequest="250">
             <VerticalStackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/ApplyMosaicRule.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ApplyMosaicRule/ApplyMosaicRule.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <ScrollView>

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="350" Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml
@@ -4,7 +4,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <HorizontalStackLayout Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         Style="{DynamicResource EsriSampleGeoView}"
                         ViewpointChanged="MyMapView_ViewpointChanged" />

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         DrawStatusChanged="MapDrawStatusChanged"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="350" Style="{DynamicResource EsriSampleControlPanel}">
             <!--  View is being done mostly in code, not XAML, because of buggy listview behavior and no option to specify a maximum height.  -->

--- a/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <VerticalStackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Grid.Row="1"

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml
@@ -4,7 +4,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border MinimumWidthRequest="400" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}" WidthRequest="200">
             <StackLayout Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Label x:Name="PositioningLabel" Padding="5" />

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout>

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid MaximumWidthRequest="200"

--- a/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{StaticResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5">

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <ActivityIndicator x:Name="SaveMapProgressBar"
                            Grid.RowSpan="2"

--- a/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <HorizontalStackLayout Padding="5" Spacing="5">

--- a/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/ChangeBasemap.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/ChangeBasemap/ChangeBasemap.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:toolkit="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <toolkit:BasemapGallery x:Name="MyBasemapGallery"

--- a/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout Padding="5">

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <StackLayout HorizontalOptions="Center" VerticalOptions="Start">

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Button x:Name="TakeMapOfflineButton"

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.xaml
@@ -28,7 +28,7 @@
             </ViewCell>
         </DataTemplate>
     </ContentPage.Resources>
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <ScrollView HeightRequest="250">

--- a/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <ScrollView Padding="5" MaximumHeightRequest="300">

--- a/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml
@@ -4,7 +4,7 @@
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:mapping="clr-namespace:Esri.ArcGISRuntime.Mapping;assembly=Esri.ArcGISRuntime"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <ScrollView>

--- a/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Button x:Name="TakeMapOfflineButton"

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Button x:Name="MapsButton"

--- a/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/SetMaxExtent.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetMaxExtent/SetMaxExtent.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="auto,auto"

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowSpacing="3">

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         Style="{DynamicResource EsriSampleGeoView}"
                         ViewInsets="0" />

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/DisplayGrid.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayGrid/DisplayGrid.xaml
@@ -4,7 +4,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Grid.Row="1" RowDefinitions="auto,auto,auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto,auto,auto,auto" RowSpacing="5">

--- a/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/MapRotation.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/MapRotation/MapRotation.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid ColumnDefinitions="50,*" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/ShowCallout.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowCallout/ShowCallout.xaml
@@ -4,7 +4,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml
+++ b/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Padding="5" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Padding="5" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Padding="5" Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="MyMapView_OnGeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}"

--- a/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/ChangeAtmosphereEffect.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ChangeAtmosphereEffect/ChangeAtmosphereEffect.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5">

--- a/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid>

--- a/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml
@@ -4,7 +4,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:SceneView x:Name="MySceneView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid Padding="5" RowDefinitions="auto">

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         Style="{DynamicResource EsriSampleGeoView}"
                         ViewpointChanged="MapViewExtentChanged" />

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <ScrollView>

--- a/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/UniqueValuesAlternateSymbols.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/UniqueValuesAlternateSymbols/UniqueValuesAlternateSymbols.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <Grid RowDefinitions="auto,auto">

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
     xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         NavigationCompleted="OnNavigationCompleted"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
     xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="MyMapView_GeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
              xmlns:resources="clr-namespace:ArcGIS.Resources">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="OnGeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}" />

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid Style="{DynamicResource EsriSampleContainer}">
+    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView"
                         GeoViewTapped="OnGeoViewTapped"
                         Style="{DynamicResource EsriSampleGeoView}" />


### PR DESCRIPTION
# Description

There is an outstanding memory leak issue with .NET MAUI when referencing a DynamicResource style for Grid elements. This change addresses this issue and prevents some memory leaks when running the sample viewer on Windows.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
