### PR TITLE
GeometryEditor -> Editing namespace changes

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -12,7 +12,7 @@ using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
-using Esri.ArcGISRuntime.UI.GeometryEditor;
+using Esri.ArcGISRuntime.UI.Editing;
 using Color = System.Drawing.Color;
 
 namespace ArcGIS.Samples.CreateAndEditGeometries

--- a/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -13,7 +13,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
-using Esri.ArcGISRuntime.UI.GeometryEditor;
+using Esri.ArcGISRuntime.UI.Editing;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -13,7 +13,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
-using Esri.ArcGISRuntime.UI.GeometryEditor;
+using Esri.ArcGISRuntime.UI.Editing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;


### PR DESCRIPTION
# Description

Applies the namespace change to `CreateAndEditGeometries`

## Type of change

<!--- Delete any that don't apply -->

- Refactoring

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
