### PR TITLE
Update UWP sample viewer to reference 200.2.0 packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Esri.ArcGISRuntime.WinUI" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Hydrography" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="100.15.0" />
-    <PackageVersion Include="Esri.ArcGISRuntime.UWP" Version="200.0.0" />
-    <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.UWP" Version="200.0.0" />
+    <PackageVersion Include="Esri.ArcGISRuntime.UWP" Version="$(ArcGISMapsSDKVersion)" />
+    <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.UWP" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Markdig" Version="0.30.4" />
     <PackageVersion Include="System.Text.Json" Version="7.0.1" />
     <PackageVersion Include="System.Speech" Version="7.0.0" />


### PR DESCRIPTION
# Description

This has been previously missed so we are updating the package referencing to ensure the UWP sample viewer references the up to date packages.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
