### PR TITLE
Fix WPF NetFramework sample viewer after local json file removed

### DIFF
--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.NetFramework.csproj
@@ -148,7 +148,6 @@
     <Content Include="Resources\hide-header.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <EmbeddedResource Include="Samples\Layers\AddCustomDynamicEntityDataSource\AIS_MarineCadastre_SelectedVessels_CustomDataSource.json" />
     <Resource Include="Resources\Fonts\calcite-ui-icons-24.ttf" />
     <Resource Include="Assets\**\*.png" />
     <Resource Include="Assets\ApplicationIcons\windows-desktop-256.ico" />


### PR DESCRIPTION
# Description

WPF NetFramework was broken when a json file was removed but the link was not removed from the NetFramework project. 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF Framework
