### PR TITLE
Android SceneView memory increase

### DIFF
--- a/src/MAUI/Maui.Samples/MauiProgram.cs
+++ b/src/MAUI/Maui.Samples/MauiProgram.cs
@@ -7,6 +7,9 @@ public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
+#if __ANDROID__
+   Esri.ArcGISRuntime.UI.Controls.SceneView.MemoryLimit = 2 * 1073741824L; // 2Gb
+#endif
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()

--- a/src/MAUI/Maui.Samples/MauiProgram.cs
+++ b/src/MAUI/Maui.Samples/MauiProgram.cs
@@ -1,14 +1,14 @@
 ﻿namespace ArcGIS.Samples.Maui;
 
-using Esri.ArcGISRuntime.Maui;
 using CommunityToolkit.Maui;
+using Esri.ArcGISRuntime.Maui;
 
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
 #if __ANDROID__
-   Esri.ArcGISRuntime.UI.Controls.SceneView.MemoryLimit = 2 * 1073741824L; // 2Gb
+        Esri.ArcGISRuntime.UI.Controls.SceneView.MemoryLimit = 2 * 1073741824L; // 2Gb
 #endif
         var builder = MauiApp.CreateBuilder();
         builder


### PR DESCRIPTION
# Description

Increases SceneView memory limit to 2 Gb for Android devices. This should help render 3D scenes after opening multiple samples.

## Type of change

- Bug fix