### PR TITLE
`CreateAndEditGeometries` scale mode fix

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
@@ -63,7 +63,7 @@
                                    Padding="1"
                                    Background="{AppThemeBinding Light={StaticResource White},
                                                                 Dark={StaticResource Dark}}">
-                <CheckBox CheckedChanged="CheckBox_CheckedChanged" />
+                <CheckBox x:Name="UniformScaleCheckBox" CheckedChanged="CheckBox_CheckedChanged" />
                 <Label Text="Uniform Scale" VerticalOptions="Center" />
             </HorizontalStackLayout>
             <Button Grid.Row="4"

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -196,7 +196,7 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
         private void CheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
         {
             // Determine the newly selected scale mode.
-            GeometryEditorScaleMode scaleMode = 
+            GeometryEditorScaleMode scaleMode =
                 (sender as CheckBox).IsChecked ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
             // Update the scale mode for every tool.

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -138,6 +138,9 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
                 // Disable the combo box as this is always a vertex tool when creating a point.
                 ToolPicker.IsEnabled = false;
 
+                // Disable scale checkbox since points don't scale.
+                UniformScaleCheckBox.IsEnabled = false;
+
                 _geometryEditor.Start(GeometryType.Point);
             }
         }
@@ -197,7 +200,7 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
         {
             // Determine the newly selected scale mode.
             GeometryEditorScaleMode scaleMode =
-                (sender as CheckBox).IsChecked ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
+                UniformScaleCheckBox.IsChecked ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
             // Update the scale mode for every tool.
             foreach (GeometryEditorTool tool in _toolDictionary.Values)
@@ -299,9 +302,14 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
 
             // Configure the UI depending on the geometry type.
             GeometryType geometryType = _selectedGraphic.Geometry.GeometryType;
-            if (geometryType == GeometryType.Point || geometryType == GeometryType.Multipoint)
+            if (geometryType == GeometryType.Point)
             {
-                ToolPicker.SelectedIndex = 0;
+                ToolComboBox.SelectedIndex = 0;
+                UniformScaleCheckBox.IsEnabled = false;
+            }
+            if (geometryType == GeometryType.Multipoint)
+            {
+                ToolComboBox.SelectedIndex = 0;
             }
             DisableOtherGeometryButtons(_geometryButtons[geometryType]);
 
@@ -353,6 +361,8 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = _geometryEditor.Tool is VertexTool;
             PolylineButton.IsEnabled = PolygonButton.IsEnabled = true;
             ToolPicker.IsEnabled = true;
+
+            UniformScaleCheckBox.IsEnabled = true;
         }
 
         // Return the graphic style based on geometry type.

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -210,9 +210,9 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
                 {
                     vertexTool.Configuration.ScaleMode = scaleMode;
                 }
-                else
+                else if (tool is ShapeTool shapeTool)
                 {
-                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                    shapeTool.Configuration.ScaleMode = scaleMode;
                 }
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -192,16 +192,28 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = !_geometryEditor.IsStarted && tool is VertexTool;
         }
 
-        // Set the scale mode of the geometry editor.
+        // Set the scale mode for every geometry editor tool.
         private void CheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
         {
-            // Determine if shape tools should use uniform scaling.
-            GeometryEditorScaleMode shouldBeUniform = (sender as CheckBox).IsChecked ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
+            // Determine the newly selected scale mode.
+            GeometryEditorScaleMode scaleMode = 
+                (sender as CheckBox).IsChecked ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
-            // Update all shape tools scaling options.
-            foreach (ShapeTool tool in _toolDictionary.Values.Where(v => v is ShapeTool))
+            // Update the scale mode for every tool.
+            foreach (GeometryEditorTool tool in _toolDictionary.Values)
             {
-                tool.Configuration.ScaleMode = shouldBeUniform;
+                if (tool is FreehandTool freehandTool)
+                {
+                    freehandTool.Configuration.ScaleMode = scaleMode;
+                }
+                else if (tool is VertexTool vertexTool)
+                {
+                    vertexTool.Configuration.ScaleMode = scaleMode;
+                }
+                else
+                {
+                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                }
             }
         }
 

--- a/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
+++ b/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
@@ -70,7 +70,8 @@
                     Grid.ColumnSpan="2"
                     Margin="5"
                     Background="White">
-                <CheckBox Margin="5"
+                <CheckBox x:Name="UniformScaleCheckBox"
+                          Margin="5"
                           Checked="CheckBox_CheckedChanged"
                           Content="Uniform scale"
                           Unchecked="CheckBox_CheckedChanged" />

--- a/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -145,6 +145,9 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
                 // Disable the combo box as this is always a vertex tool when creating a point.
                 ToolComboBox.IsEnabled = false;
 
+                // Disable scale checkbox since points don't scale.
+                UniformScaleCheckBox.IsEnabled = false;
+
                 _geometryEditor.Start(GeometryType.Point);
             }
         }
@@ -204,7 +207,7 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
         {
             // Determine the newly selected scale mode.
             GeometryEditorScaleMode scaleMode =
-                (sender as CheckBox).IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
+                UniformScaleCheckBox.IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
             // Update the scale mode for every tool.
             foreach (GeometryEditorTool tool in _toolDictionary.Values)
@@ -305,7 +308,12 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
 
             // Configure the UI depending on the geometry type.
             GeometryType geometryType = _selectedGraphic.Geometry.GeometryType;
-            if (geometryType == GeometryType.Point || geometryType == GeometryType.Multipoint)
+            if (geometryType == GeometryType.Point)
+            {
+                ToolComboBox.SelectedIndex = 0;
+                UniformScaleCheckBox.IsEnabled = false;
+            }
+            if (geometryType == GeometryType.Multipoint)
             {
                 ToolComboBox.SelectedIndex = 0;
             }
@@ -359,6 +367,8 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = _geometryEditor.Tool is VertexTool;
             PolylineButton.IsEnabled = PolygonButton.IsEnabled = true;
             ToolComboBox.IsEnabled = true;
+
+            UniformScaleCheckBox.IsEnabled = true;
         }
 
         // Return the graphic style based on geometry type.

--- a/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -217,9 +217,9 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
                 {
                     vertexTool.Configuration.ScaleMode = scaleMode;
                 }
-                else
+                else if (tool is ShapeTool shapeTool)
                 {
-                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                    shapeTool.Configuration.ScaleMode = scaleMode;
                 }
             }
         }

--- a/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -199,17 +199,28 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = !_geometryEditor.IsStarted && _geometryEditor.Tool is VertexTool;
         }
 
-        // Set the scale mode of the geometry editor.
+        // Set the scale mode for every geometry editor tool.
         private void CheckBox_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            // Determine if shape tools should use uniform scaling.
-            GeometryEditorScaleMode shouldBeUniform =
+            // Determine the newly selected scale mode.
+            GeometryEditorScaleMode scaleMode =
                 (sender as CheckBox).IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
-            // Update all shape tools scaling options.
-            foreach (ShapeTool tool in _toolDictionary.Values.Where(v => v is ShapeTool))
+            // Update the scale mode for every tool.
+            foreach (GeometryEditorTool tool in _toolDictionary.Values)
             {
-                tool.Configuration.ScaleMode = shouldBeUniform;
+                if (tool is FreehandTool freehandTool)
+                {
+                    freehandTool.Configuration.ScaleMode = scaleMode;
+                }
+                else if (tool is VertexTool vertexTool)
+                {
+                    vertexTool.Configuration.ScaleMode = scaleMode;
+                }
+                else
+                {
+                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                }
             }
         }
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml
@@ -72,7 +72,8 @@
                     Grid.ColumnSpan="2"
                     Padding="3"
                     Background="White">
-                <CheckBox Checked="CheckBox_CheckedChanged"
+                <CheckBox x:Name="UniformScaleCheckBox"
+                          Checked="CheckBox_CheckedChanged"
                           Content="Uniform Scale"
                           Unchecked="CheckBox_CheckedChanged" />
             </Border>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -145,6 +145,9 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
                 // Disable the combo box as this is always a vertex tool when creating a point.
                 ToolComboBox.IsEnabled = false;
 
+                // Disable scale checkbox since points don't scale.
+                UniformScaleCheckBox.IsEnabled = false;
+
                 _geometryEditor.Start(GeometryType.Point);
             }
         }
@@ -204,7 +207,7 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
         {
             // Determine the newly selected scale mode.
             GeometryEditorScaleMode scaleMode =
-                (sender as CheckBox).IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
+                UniformScaleCheckBox.IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
             // Update the scale mode for every tool.
             foreach (GeometryEditorTool tool in _toolDictionary.Values)
@@ -306,7 +309,12 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
 
             // Configure the UI depending on the geometry type.
             GeometryType geometryType = _selectedGraphic.Geometry.GeometryType;
-            if (geometryType == GeometryType.Point || geometryType == GeometryType.Multipoint)
+            if (geometryType == GeometryType.Point)
+            {
+                ToolComboBox.SelectedIndex = 0;
+                UniformScaleCheckBox.IsEnabled = false;
+            }
+            if (geometryType == GeometryType.Multipoint)
             {
                 ToolComboBox.SelectedIndex = 0;
             }
@@ -360,6 +368,8 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = _geometryEditor.Tool is VertexTool;
             PolylineButton.IsEnabled = PolygonButton.IsEnabled = true;
             ToolComboBox.IsEnabled = true;
+
+            UniformScaleCheckBox.IsEnabled = true;
         }
 
         // Return the graphic style based on geometry type.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -199,17 +199,28 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
             PointButton.IsEnabled = MultipointButton.IsEnabled = !_geometryEditor.IsStarted && _geometryEditor.Tool is VertexTool;
         }
 
-        // Set the scale mode of the geometry editor.
+        // Set the scale mode for every geometry editor tool.
         private void CheckBox_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            // Determine if shape tools should use uniform scaling.
-            GeometryEditorScaleMode shouldBeUniform =
+            // Determine the newly selected scale mode.
+            GeometryEditorScaleMode scaleMode =
                 (sender as CheckBox).IsChecked == true ? GeometryEditorScaleMode.Uniform : GeometryEditorScaleMode.Stretch;
 
-            // Update all shape tools scaling options.
-            foreach (ShapeTool tool in _toolDictionary.Values.Where(v => v is ShapeTool))
+            // Update the scale mode for every tool.
+            foreach (GeometryEditorTool tool in _toolDictionary.Values)
             {
-                tool.Configuration.ScaleMode = shouldBeUniform;
+                if (tool is FreehandTool freehandTool)
+                {
+                    freehandTool.Configuration.ScaleMode = scaleMode;
+                }
+                else if (tool is VertexTool vertexTool)
+                {
+                    vertexTool.Configuration.ScaleMode = scaleMode;
+                }
+                else
+                {
+                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                }
             }
         }
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -217,9 +217,9 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
                 {
                     vertexTool.Configuration.ScaleMode = scaleMode;
                 }
-                else
+                else if (tool is ShapeTool shapeTool)
                 {
-                    (tool as ShapeTool).Configuration.ScaleMode = scaleMode;
+                    shapeTool.Configuration.ScaleMode = scaleMode;
                 }
             }
         }


### PR DESCRIPTION
# Description

- Set the scale mode for every geometry editor tool. Previously was neglecting `FreehandTool`s and `VertexTool`s.
- Disable check box control when `GeometryEditor` starts with a point.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
