### PR TITLE
Fix issue with Geodatabase transactions sample when navigating away

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -158,7 +158,7 @@ namespace ArcGIS.WPF.Samples.GeodatabaseTransactions
 
                     // Create a new feature layer to show the table in the map.
                     FeatureLayer layer = new FeatureLayer(table);
-                    Dispatcher.Invoke(() => MyMapView.Map.OperationalLayers.Add(layer));
+                    Dispatcher.Invoke(() => MyMapView.Map?.OperationalLayers.Add(layer));
                 }
                 catch (Exception e)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -166,7 +166,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
 
                     // Create a new feature layer to show the table in the map.
                     FeatureLayer layer = new FeatureLayer(table);
-                    DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () => MyMapView.Map.OperationalLayers.Add(layer));
+                    DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () => MyMapView.Map?.OperationalLayers.Add(layer));
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
# Description

A missing null check resulted in a thrown exception when navigating away from the Geodatabase transactions sample.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
