### PR TITLE
Fix MAUI build on `v.next`

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -304,12 +304,12 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
             GeometryType geometryType = _selectedGraphic.Geometry.GeometryType;
             if (geometryType == GeometryType.Point)
             {
-                ToolComboBox.SelectedIndex = 0;
+                ToolPicker.SelectedIndex = 0;
                 UniformScaleCheckBox.IsEnabled = false;
             }
             if (geometryType == GeometryType.Multipoint)
             {
-                ToolComboBox.SelectedIndex = 0;
+                ToolPicker.SelectedIndex = 0;
             }
             DisableOtherGeometryButtons(_geometryButtons[geometryType]);
 


### PR DESCRIPTION
# Description

The MAUI sample viewer wasn't building, this has been fixed.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
