### PR TITLE
Fix bug preventing symbols loading on WPF Netframework

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
@@ -217,22 +217,30 @@ namespace ArcGIS.WPF.Samples.MobileMapSearchAndRoute
 
         private async Task<Graphic> GraphicForPoint(MapPoint point)
         {
+            // Hold a reference to the picture marker symbol.
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources.
-            // Picture is defined as EmbeddedResource and DoNotCopy.
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin star image
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream.
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 60;
-            pinSymbol.Height = 60;
-            // The image is a pin; offset the image so that the pinpoint
-            //     is on the point rather than the image's true center.
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the resource stream
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+
+                // Create new symbol using asynchronous factory method from stream.
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 60;
+                pinSymbol.Height = 60;
+                // The image is a pin; offset the image so that the pinpoint
+                //     is on the point rather than the image's true center.
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
+
             return new Graphic(point, pinSymbol);
         }
     }

--- a/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -235,20 +235,26 @@ namespace ArcGIS.WPF.Samples.OfflineRouting
 
         private async Task<PictureMarkerSymbol> GetPictureMarker()
         {
+            // Hold a reference to the picture marker symbol.
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources.
-            // Picture is defined as EmbeddedResource and DoNotCopy.
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_blue.png");
+            // Get the resource name of the blue pin image.
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream.
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 50;
-            pinSymbol.Height = 50;
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream.
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream.
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 50;
+                pinSymbol.Height = 50;
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
 
             return pinSymbol;
         }

--- a/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Xml.Linq;
 using Geometry = Esri.ArcGISRuntime.Geometry.Geometry;
 
 using Symbology = Esri.ArcGISRuntime.Symbology;
@@ -292,20 +293,26 @@ namespace ArcGIS.WPF.Samples.RouteAroundBarriers
 
         private async Task<PictureMarkerSymbol> GetPictureMarker()
         {
+            // Hold a reference to the picture marker symbol
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources
-            // Picture is defined as EmbeddedResource and DoNotCopy
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_blue.png");
+            // Get the resource name of the blue pin image
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 50;
-            pinSymbol.Height = 50;
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 50;
+                pinSymbol.Height = 50;
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
 
             return pinSymbol;
         }

--- a/src/WPF/WPF.Viewer/Samples/Search/FindAddress/FindAddress.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindAddress/FindAddress.xaml.cs
@@ -136,22 +136,29 @@ namespace ArcGIS.WPF.Samples.FindAddress
         /// </summary>
         private async Task<Graphic> GraphicForPoint(MapPoint point)
         {
+            // Hold a reference to the picture marker symbol
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources
-            // Picture is defined as EmbeddedResource and DoNotCopy
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin image
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 60;
-            pinSymbol.Height = 60;
-            // The image is a pin; offset the image so that the pinpoint
-            //     is on the point rather than the image's true center
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 60;
+                pinSymbol.Height = 60;
+                // The image is a pin; offset the image so that the pinpoint
+                //     is on the point rather than the image's true center
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
+
             return new Graphic(point, pinSymbol);
         }
 

--- a/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -222,22 +222,29 @@ namespace ArcGIS.WPF.Samples.FindPlace
         /// </summary>
         private async Task<Graphic> GraphicForPoint(MapPoint point)
         {
+            // Hold a reference to the picture marker symbol.
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources.
-            // Picture is defined as EmbeddedResource and DoNotCopy.
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin image.
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream.
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 60;
-            pinSymbol.Height = 60;
-            // The symbol is a pin; centering it on the point is incorrect.
-            // The values below center the pin and offset it so that the pinpoint is accurate.
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream.
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream.
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 60;
+                pinSymbol.Height = 60;
+                // The symbol is a pin; centering it on the point is incorrect.
+                // The values below center the pin and offset it so that the pinpoint is accurate.
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
+
             return new Graphic(point, pinSymbol);
         }
 

--- a/src/WPF/WPF.Viewer/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
@@ -200,22 +200,29 @@ namespace ArcGIS.WPF.Samples.OfflineGeocode
 
         private async Task<Graphic> GraphicForPoint(MapPoint point)
         {
+            // Hold a reference to the picture marker symbol.
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources.
-            // Picture is defined as EmbeddedResource and DoNotCopy.
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin image.
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream.
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 60;
-            pinSymbol.Height = 60;
-            // The image is a pin; offset the image so that the pinpoint
-            //     is on the point rather than the image's true center.
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream.
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream.
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 60;
+                pinSymbol.Height = 60;
+                // The image is a pin; offset the image so that the pinpoint
+                //     is on the point rather than the image's true center.
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
+
             return new Graphic(point, pinSymbol);
         }
     }

--- a/src/WPF/WPF.Viewer/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
@@ -116,22 +116,29 @@ namespace ArcGIS.WPF.Samples.ReverseGeocode
 
         private async Task<Graphic> GraphicForPoint(MapPoint point)
         {
+            // Hold a reference to the picture marker symbol.
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources.
-            // Picture is defined as EmbeddedResource and DoNotCopy.
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin image.
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream.
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 60;
-            pinSymbol.Height = 60;
-            // The image is a pin; offset the image so that the pinpoint
-            //     is on the point rather than the image's true center.
-            pinSymbol.LeaderOffsetX = 30;
-            pinSymbol.OffsetY = 14;
+            // Load the blue pin resource stream.
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream.
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 60;
+                pinSymbol.Height = 60;
+                // The image is a pin; offset the image so that the pinpoint
+                //     is on the point rather than the image's true center.
+                pinSymbol.LeaderOffsetX = 30;
+                pinSymbol.OffsetY = 14;
+            }
+
             return new Graphic(point, pinSymbol);
         }
     }

--- a/src/WPF/WPF.Viewer/Samples/Symbology/RenderMultilayerSymbols/RenderMultilayerSymbols.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Symbology/RenderMultilayerSymbols/RenderMultilayerSymbols.xaml.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace ArcGIS.WPF.Samples.RenderMultilayerSymbols
@@ -197,9 +198,12 @@ namespace ArcGIS.WPF.Samples.RenderMultilayerSymbols
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
+            // Get the resource name of the blue pin image
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
+
             // Get image as a stream from the resources.
             // Picture is defined as EmbeddedResource.
-            using (var stream = currentAssembly.GetManifestResourceStream("ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png"))
+            using (var stream = currentAssembly.GetManifestResourceStream(resourceStreamName))
             {
                 using (var mem = new MemoryStream())
                 {

--- a/src/WPF/WPF.Viewer/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
@@ -13,6 +13,7 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -93,18 +94,24 @@ namespace ArcGIS.WPF.Samples.RenderPictureMarkers
 
         private async Task CreatePictureMarkerSymbolFromResources(GraphicsOverlay overlay)
         {
+            // Hold a reference to the picture marker symbol
+            PictureMarkerSymbol pinSymbol;
+
             // Get current assembly that contains the image
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
 
-            // Get image as a stream from the resources
-            // Picture is defined as EmbeddedResource and DoNotCopy
-            Stream resourceStream = currentAssembly.GetManifestResourceStream(
-                "ArcGIS.Resources.PictureMarkerSymbols.pin_star_blue.png");
+            // Get the resource name of the blue pin image
+            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith("pin_star_blue.png"));
 
-            // Create new symbol using asynchronous factory method from stream
-            PictureMarkerSymbol pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
-            pinSymbol.Width = 50;
-            pinSymbol.Height = 50;
+            // Load the blue pin resource stream
+            using (Stream resourceStream = this.GetType().Assembly.
+                       GetManifestResourceStream(resourceStreamName))
+            {
+                // Create new symbol using asynchronous factory method from stream
+                pinSymbol = await PictureMarkerSymbol.CreateAsync(resourceStream);
+                pinSymbol.Width = 50;
+                pinSymbol.Height = 50;
+            }
 
             // Create location for the pint
             MapPoint pinPoint = new MapPoint(-226773, 6550477, SpatialReferences.WebMercator);


### PR DESCRIPTION
# Description

Symbols have not been loading correctly in the WPF Netframework sample viewer, this has been addressed.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
