### PR TITLE
Vector tiled layer custom style cache fix

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
@@ -137,13 +137,16 @@ namespace ArcGIS.Samples.AddVectorTiledLayerFromCustomStyle
                 ExportVectorTilesTask exportTask = await ExportVectorTilesTask.CreateAsync(vectorTiledLayer.Url);
 
                 // Get the item resource path for the basemap styling.
-                string itemResourcePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
+                string itemResourceCachePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
 
                 // If cache has been created previously, return.
-                if (Directory.Exists(itemResourcePath)) { return new ItemResourceCache(itemResourcePath); }
+                if (Directory.Exists(itemResourceCachePath) && (Directory.GetFiles(itemResourceCachePath).Length != 0))
+                {
+                    return new ItemResourceCache(itemResourceCachePath);
+                }
 
                 // Create the export job and start it.
-                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourcePath);
+                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourceCachePath);
                 job.Start();
 
                 // Wait for the job to complete.

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
@@ -143,13 +143,16 @@ namespace ArcGIS.WPF.Samples.AddVectorTiledLayerFromCustomStyle
                 ExportVectorTilesTask exportTask = await ExportVectorTilesTask.CreateAsync(vectorTiledLayer.Url);
 
                 // Get the item resource path for the basemap styling.
-                string itemResourcePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
+                string itemResourceCachePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
 
                 // If cache has been created previously, return.
-                if (Directory.Exists(itemResourcePath)) { return new ItemResourceCache(itemResourcePath); }
+                if (Directory.Exists(itemResourceCachePath) && (Directory.GetFiles(itemResourceCachePath).Length != 0))
+                {
+                    return new ItemResourceCache(itemResourceCachePath);
+                }
 
                 // Create the export job and start it.
-                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourcePath);
+                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourceCachePath);
                 job.Start();
 
                 // Wait for the job to complete.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
@@ -142,13 +142,16 @@ namespace ArcGIS.WinUI.Samples.AddVectorTiledLayerFromCustomStyle
                 ExportVectorTilesTask exportTask = await ExportVectorTilesTask.CreateAsync(vectorTiledLayer.Url);
 
                 // Get the item resource path for the basemap styling.
-                string itemResourcePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
+                string itemResourceCachePath = Path.Combine(Path.GetTempPath(), vectorTiledLayer.ItemId + "_styleItemResources");
 
                 // If cache has been created previously, return.
-                if (Directory.Exists(itemResourcePath)) { return new ItemResourceCache(itemResourcePath); }
+                if (Directory.Exists(itemResourceCachePath) && (Directory.GetFiles(itemResourceCachePath).Length != 0))
+                {
+                    return new ItemResourceCache(itemResourceCachePath);
+                }
 
                 // Create the export job and start it.
-                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourcePath);
+                ExportVectorTilesJob job = exportTask.ExportStyleResourceCache(itemResourceCachePath);
                 job.Start();
 
                 // Wait for the job to complete.


### PR DESCRIPTION
# Description

We were only checking if the directory existed, not if the cache inside the directory actually existed. This prevented cache from being created if the directory already existed.

Renamed `itemResourcePath` to `itemResourceCachePath` for clarity and consistency with the ExportStyleResourceCache() parameter name.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
