### PR TITLE
`v.next`: move to .NET 8

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ArcGISMapsSDKVersion>200.2.0</ArcGISMapsSDKVersion>
+    <ArcGISMapsSDKVersion>200.3.0</ArcGISMapsSDKVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Esri.ArcGISRuntime" Version="$(ArcGISMapsSDKVersion)" />
@@ -33,6 +33,6 @@
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha"/>
     <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.1.9171" />
-	<PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3"/>
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3"/>
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,12 +25,14 @@
     <PackageVersion Include="CommunityToolkit.Maui" Version="5.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.1.0" />
     <PackageVersion Include="WinUIEx" Version="1.8.0" />
-    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.5.1.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221116.1" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13"/>
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1"/>
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0"/>
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha"/>
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.1.9171" />
+	<PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3"/>
   </ItemGroup>
 </Project>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
@@ -20,7 +20,7 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ArcGIS.Samples</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -61,7 +61,7 @@
 	</ItemGroup>
 
 	<!-- Exclude Indoor Positioning on desktop platforms -->
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net7.0-maccatalyst')) or $(TargetFramework.StartsWith('net7.0-windows'))">
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-maccatalyst')) or $(TargetFramework.StartsWith('net8.0-windows'))">
 	  <AndroidResource Remove="Samples\Location\IndoorPositioning\**" />
 	  <Compile Remove="Samples\Location\IndoorPositioning\**" />
 	  <MauiCss Remove="Samples\Location\IndoorPositioning\**" />
@@ -135,14 +135,16 @@
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Maui" />
     <PackageReference Include="Markdig" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="Microsoft.Maui.Controls"/>
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility"/>
   </ItemGroup>
 
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-windows10.0.19041.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
     <PackageReference Include="WinUIEx" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
     <PackageReference Include="Xamarin.AndroidX.AppCompat" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -20,11 +20,11 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 		<RootNamespace>ArcGIS</RootNamespace>
 		<AssemblyName>ArcGIS</AssemblyName>
         <DefineConstants>$(DefineConstants);MAUI</DefineConstants>

--- a/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
+++ b/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.samples.maui" android:versionCode="1" android:versionName="1.0">
 	<application android:allowBackup="true" android:usesCleartextTraffic="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:label="ArcGIS.Samples.Maui"></application>
-	<uses-sdk android:minSdkVersion="26" android:targetSdkVersion="33" />
+	<uses-sdk android:minSdkVersion="26" android:targetSdkVersion="34" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/src/WPF/WPF.StorePackage/ArcGIS.WPF.StorePackage.wapproj
+++ b/src/WPF/WPF.StorePackage/ArcGIS.WPF.StorePackage.wapproj
@@ -43,9 +43,9 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>13a60801-7b9a-4573-923f-9f2373e8bf84</ProjectGuid>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageCertificateKeyFile>ArcGIS.WPF.StorePackage_TemporaryKey.pfx</PackageCertificateKeyFile>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
@@ -100,9 +100,9 @@
   <ItemGroup>
     <ProjectReference Include="..\WPF.Viewer\ArcGIS.WPF.Viewer.Net.csproj">
       <SkipGetTargetFrameworkProperties>True</SkipGetTargetFrameworkProperties>
-      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Properties\PublishProfiles\win10-x64-release.pubxml</PublishProfile>
-      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|x86'">Properties\PublishProfiles\win10-x86-release.pubxml</PublishProfile>
-      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Properties\PublishProfiles\win10-arm64-release.pubxml</PublishProfile>
+      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Properties\PublishProfiles\win-x64-release.pubxml</PublishProfile>
+      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|x86'">Properties\PublishProfiles\win-x86-release.pubxml</PublishProfile>
+      <PublishProfile Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Properties\PublishProfiles\win-arm64-release.pubxml</PublishProfile>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <ArcGISLocalServerIgnoreMissingComponent>True</ArcGISLocalServerIgnoreMissingComponent>
@@ -13,7 +13,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishTrimmed>false</PublishTrimmed>
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <DefineConstants>$(DefineConstants);TRACE;NET_CORE_3</DefineConstants>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -15,7 +15,7 @@
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
-    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <DefineConstants>$(DefineConstants);TRACE;NET_CORE_3</DefineConstants>
     <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>

--- a/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-arm64-release.pubxml
+++ b/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-arm64-release.pubxml
@@ -7,9 +7,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>arm64</Platform>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <PublishDir>..\..\..\output\WPFNet\Release\net6\win10-arm64\publish\</PublishDir>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <PublishDir>..\..\..\output\WPFNet\Release\net8\win-arm64\publish\</PublishDir>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <_IsPortable>false</_IsPortable>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-x64-release.pubxml
+++ b/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-x64-release.pubxml
@@ -7,9 +7,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <PublishDir>..\..\..\output\WPFNet\Release\net6\win10-x64\publish\</PublishDir>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <PublishDir>..\..\..\output\WPFNet\Release\net8\win-x64\publish\</PublishDir>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <_IsPortable>false</_IsPortable>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-x86-release.pubxml
+++ b/src/WPF/WPF.Viewer/Properties/PublishProfiles/win-x86-release.pubxml
@@ -7,9 +7,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x86</Platform>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <PublishDir>..\..\..\output\WPFNet\Release\net6\win10-x86\publish\</PublishDir>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <PublishDir>..\..\..\output\WPFNet\Release\net8\win-x86\publish\</PublishDir>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <_IsPortable>false</_IsPortable>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -7,14 +7,14 @@
     <RootNamespace>ArcGIS.WinUI.Viewer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <ArcGISLocalServerIgnoreMissingComponent>True</ArcGISLocalServerIgnoreMissingComponent>
     <OutputPath>..\..\..\output\WinUI\$(Configuration)\$(Platform)\</OutputPath>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WinUI</DefineConstants>
-	<UseRidGraph>true</UseRidGraph>
+	  <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -14,7 +14,7 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WinUI</DefineConstants>
-	  <UseRidGraph>true</UseRidGraph>
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RootNamespace>ArcGIS.WinUI.Viewer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <ArcGISLocalServerIgnoreMissingComponent>True</ArcGISLocalServerIgnoreMissingComponent>
     <OutputPath>..\..\..\output\WinUI\$(Configuration)\$(Platform)\</OutputPath>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WinUI</DefineConstants>
+	<UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Use .NET 8 in `v.next` branch. Use ArcGIS Maps SDK 200.3. Enforce 200.3 minimum requirements.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

NOTE: on Mac, in `src` open a terminal:
`dotnet build -t:Run -f net8.0-ios`
`dotnet build -t:Run -f net8.0-maccatalyst`
Visual Studio for Mac will not recognize the target platform identifiers, so must deploy from CLI.

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files

CC: @duffh @car10567