### PR TITLE
Updating offline file name for the sample 'Add custom dynamic entity data source' for WPF and WinUI projects

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
@@ -30,7 +30,7 @@ namespace ArcGIS.Samples.AddCustomDynamicEntityDataSource
     public partial class AddCustomDynamicEntityDataSource
     {
         // Path to AIS Traffic Data json file.
-        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.json");
+        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.jsonl");
 
         public AddCustomDynamicEntityDataSource()
         {

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
@@ -33,7 +33,7 @@ namespace ArcGIS.WPF.Samples.AddCustomDynamicEntityDataSource
     public partial class AddCustomDynamicEntityDataSource
     {
         // Path to AIS Traffic Data json file.
-        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.json");
+        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.jsonl");
 
         public AddCustomDynamicEntityDataSource()
         {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGIS.WinUI.Samples.AddCustomDynamicEntityDataSource
     public partial class AddCustomDynamicEntityDataSource
     {
         // Path to AIS Traffic Data json file.
-        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.json");
+        private readonly string _localJsonFile = DataManager.GetDataFolder("a8a942c228af4fac96baa78ad60f511f", "AIS_MarineCadastre_SelectedVessels_CustomDataSource.jsonl");
 
         public AddCustomDynamicEntityDataSource()
         {


### PR DESCRIPTION
# Description

The sample `Add custom dynamic entity data source` currently does not display the data as described, and only displays the map. 

This is because the file name of the offline file in the code is not the same as the actual file being downloaded from the [resource link](https://www.arcgis.com/home/item.html?id=a8a942c228af4fac96baa78ad60f511f). The code has the file name `AIS_MarineCadastre_SelectedVessels_CustomDataSource.json`, whereas the actual file being downloaded has the file name `AIS_MarineCadastre_SelectedVessels_CustomDataSource.jsonl`. 

(To reproduce the above bug, and if you've had the application installed/cloned on your machine before, please make sure to remove any existing offline resource related to this particular sample, in the location `C:\Users\{UserName}\AppData\Local\ArcGISSampleData\a8a942c228af4fac96baa78ad60f511f`, as there are changes that the file that was downloaded previously has the `.json` extension and not the `.jsonl` extension as given in the resource. Removing the resource prompts the app to redownload the resource, reproducing the error correctly).  

## Type of change

- Bug fix

## Platforms tested on


- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)

## Screenshots

### Before the change:

WinUI:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/0152567d-9731-49c7-af56-74b46a7c522b)

WPF:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/11726256-78e4-453b-ab19-b0009410e073)

Maui:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/e4f5aef6-e1fa-4403-9ac2-f3301d853e95)


### After the change:

WinUI:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/48faa895-c661-48f8-8196-3cf800ca6cbc)

WPF:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/2a0c4256-0c7f-4468-86ca-22d7a95025f3)

Maui:
![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/assets/83402878/c14d0cd9-c924-412a-a50d-357030750270)

