### PR TITLE
Strip exited 139 workaround

### DIFF
--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -30,6 +30,12 @@
         <DefineConstants>$(DefineConstants);MAUI</DefineConstants>
 	</PropertyGroup>
 
+    <!-- Workaround for error : strip exited with code 139-->
+    <!-- https://github.com/xamarin/xamarin-macios/issues/19157 -->
+    <PropertyGroup>
+      <MtouchNoSymbolStrip Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">True</MtouchNoSymbolStrip>
+    </PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\arcgissdkglyphfg.svg" />


### PR DESCRIPTION
# Description

Workaround for error : strip exited with code 139
https://github.com/xamarin/xamarin-macios/issues/19157

This error prevents the app from installing on iOS devices. 

Note that the app will install on an iOS device, but will not launch automatically due to an unrelated issue.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files