### PR TITLE
PR automation: cherry-pick from main

### DIFF
--- a/.github/workflows/Open_PR.yml
+++ b/.github/workflows/Open_PR.yml
@@ -1,5 +1,6 @@
 name: Sync v.next with main
 
+# PRs are completed with squash and merge option - this commit will be cherry-picked for v.next.
 on:
   push:
     branches:
@@ -10,21 +11,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     
+      # Clone just the main branch of the samples repo.
       - name: Checkout code
         uses: actions/checkout@v2
-        
-      - name: Open PR
+        with:
+          ref: main
+          fetch-depth: 0
+
+      # Cherry-pick the most recent commit from main into v.next.
+      - name: Cherry-pick from main into v.next
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-            if ! git diff --quiet v.next; then
-              gh pr create \
-                --title "[Automated] Sync v.next with main" \
-                --body "This PR was automaticaly opened to update v.next with the latest changes from main." \
-                --head "main" \
-                --base "v.next"
-              echo "Diff detected, pull request opened."
+          # Configure the bot's git identity.
+          git config --global user.name "ArcGIS Maps SDK [bot]"
+          git config --global user.email "arcgis-maps-sdk-bot@esri.com"
+
+          # Store the commit hash of the most recent commit from main.
+          COMMIT_HASH=$(git rev-parse HEAD)
+
+          # Name the target branch.
+          SYNC_BRANCH="sync/$COMMIT_HASH"
+
+          # Pull v.next and branch off with the cherry-picked commit.
+          git fetch origin v.next 
+          git switch v.next
+          git branch $SYNC_BRANCH
+          git switch $SYNC_BRANCH
+          git cherry-pick $COMMIT_HASH
+
+          # Push the new head branch to the remote and try to open a PR.
+          git push -u origin $SYNC_BRANCH
+          if ! git diff --quiet v.next; then
+            echo "Diff detected."
+            gh pr create \
+              --title "[Automated] Sync v.next with main" \
+              --body "This PR was automaticaly opened to update v.next with the most recent commit from main." \
+              --head "$SYNC_BRANCH" \
+              --base "v.next" || CANNOT_OPEN_PR=$?
+            if [ -n "$CANNOT_OPEN_PR" ]; then
+              echo "Failed to open PR."
+              git branch -D $SYNC_BRANCH
             else
-              echo "No diff detected."
+              echo "PR successfully opened."
             fi
-            
+          else
+            echo "No diff detected."
+            git branch -D $SYNC_BRANCH
+          fi

--- a/.github/workflows/Open_PR.yml
+++ b/.github/workflows/Open_PR.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 2
 
       # Cherry-pick the most recent commit from main into v.next.
       - name: Cherry-pick from main into v.next
@@ -34,7 +34,7 @@ jobs:
           SYNC_BRANCH="sync/$COMMIT_HASH"
 
           # Pull v.next and branch off with the cherry-picked commit.
-          git fetch origin v.next 
+          git fetch --depth=2 origin v.next 
           git switch v.next
           git branch $SYNC_BRANCH
           git switch $SYNC_BRANCH


### PR DESCRIPTION
# Description

An issue with the current `Open_PR` workflow is dealing with merge conflicts. We have a few minor but intentional differences between main and `v.next`, for example, `Directory.Packages.props`.  This results in a less streamlined process of keeping `v.next` synced with bug fixes and enhancements that go directly into `main`. 

The solution proposed is to change the head of the generated PR. Currently, that branch is `main`. Instead, we can branch off `v.next` and cherry-pick the most recent commit of `main`. This way, the head has the same commit history as `v.next` but with the additional cherry-picked commit. This will reduce the risk of merge conflicts and reduce PR scope. Multiple "sync" PRs may be opened at once since the modified job generates a new branch per commit to `main`.

Another issue with the current workflow is if a PR fails to open, the job fails. I've added some output which writes if a diff is detected and if opening a PR is successful. The job will no longer fail if the PR cannot be opened. An advantage of this modified workflow is no more opening identical PRs. The branch name will follow a convention of sync/commit-hash, where the commit hash is the most recent commit from main.

In the checkout code step, I've added parameters to checkout a shallow clone of `main` at depth 2. This truncates the git history and doesn't download history of branches unrelated to the job. The same kind of clone for `v.next` is made in the following step. 

For more, see:
- [Successful run](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/actions/runs/6699836972/job/18204699060) of this job.
- `wbohr/cherry-pick-from-main-test` commit history and triggered test runs.

## Type of change

- Automation

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
