### PR TITLE
MAUI packages and revert "strip exited 139" workaround

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,8 +31,8 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1"/>
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0"/>
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha"/>
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.1.9171" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3"/>
   </ItemGroup>
 </Project>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -30,12 +30,6 @@
         <DefineConstants>$(DefineConstants);MAUI</DefineConstants>
 	</PropertyGroup>
 
-    <!-- Workaround for error : strip exited with code 139-->
-    <!-- https://github.com/xamarin/xamarin-macios/issues/19157 -->
-    <PropertyGroup>
-      <MtouchNoSymbolStrip Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">True</MtouchNoSymbolStrip>
-    </PropertyGroup>
-
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\arcgissdkglyphfg.svg" />


### PR DESCRIPTION
# Description

- Use version 8.0.3 for .NET MAUI controls packages
- Revert "strip exited 139" workaround

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files