### PR TITLE
`ReadShapefileMetadata` visible metadata (.NET MAUI)

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml
@@ -6,58 +6,21 @@
     <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, Auto">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
-            <Grid Padding="5">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="auto" />
-                    <RowDefinition Height="auto" />
-                </Grid.RowDefinitions>
-                <ScrollView x:Name="MetadataScrollView"
-                            Grid.Row="1"
-                            IsVisible="false"
-                            MaximumHeightRequest="400">
-                    <Grid x:Name="InfoGrid">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="auto" />
-                            <RowDefinition Height="auto" />
-                            <RowDefinition Height="auto" />
-                            <RowDefinition Height="auto" />
-                        </Grid.RowDefinitions>
-                        <Label Grid.Row="0"
-                               Margin="5"
-                               FontAttributes="Bold"
-                               FontSize="Small"
-                               Text="{Binding Path=Credits}" />
-                        <Label Grid.Row="1"
-                               FontSize="Micro"
-                               LineBreakMode="WordWrap"
-                               Text="{Binding Summary}" />
-                        <Image x:Name="ShapefileThumbnailImage"
-                               Grid.Row="2"
-                               Margin="10" />
-                        <Grid Grid.Row="3">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0"
-                                   Margin="0,3"
-                                   FontAttributes="Bold"
-                                   FontSize="Micro"
-                                   Text="Tags:" />
-                            <ListView Grid.Column="1"
-                                      HeightRequest="120"
-                                      ItemsSource="{Binding Tags}"
-                                      RowHeight="25"
-                                      WidthRequest="160" />
-                        </Grid>
-                    </Grid>
-                </ScrollView>
-                <Button Grid.Row="0"
-                        Clicked="ShowMetadataClicked"
-                        HeightRequest="40"
-                        HorizontalOptions="FillAndExpand"
-                        Text="Show/Hide Metadata" />
-            </Grid>
+            <ScrollView>
+                <StackLayout x:Name="InfoList" Spacing="5">
+                    <Label FontAttributes="Bold"
+                           FontSize="Medium"
+                           Text="{Binding Path=Credits}" />
+                    <Label LineBreakMode="WordWrap" Text="{Binding Summary}" />
+                    <Image x:Name="ShapefileThumbnailImage" Margin="10" />
+                    <Label Margin="0,3"
+                           FontAttributes="Bold"
+                           Text="Tags:" />
+                    <ListView ItemsSource="{Binding Tags}"
+                              RowHeight="25"
+                              VerticalScrollBarVisibility="Never" />
+                </StackLayout>
+            </ScrollView>
         </Border>
     </Grid>
 </ContentPage>

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
@@ -26,71 +26,65 @@ namespace ArcGIS.Samples.ReadShapefileMetadata
         {
             InitializeComponent();
 
-            // Open a shapefile stored locally and add it to the map as a feature layer
+            // Open a shapefile stored locally and add it to the map as a feature layer.
             _ = Initialize();
         }
 
         private async Task Initialize()
         {
-            // Create a new map to display in the map view with a streets basemap
-            Map streetMap = new Map(BasemapStyle.ArcGISStreets);
+            // Create a new map to display in the map view with a streets basemap.
+            var streetMap = new Map(BasemapStyle.ArcGISStreets);
 
-            // Get the path to the downloaded shapefile
+            // Get the path to the downloaded shapefile.
             string filepath = GetShapefilePath();
 
             try
             {
-                // Open the shapefile
+                // Open the shapefile.
                 ShapefileFeatureTable myShapefile = await ShapefileFeatureTable.OpenAsync(filepath);
 
-                // Read metadata about the shapefile and display it in the UI
+                // Read metadata about the shapefile and display it in the UI.
                 ShapefileInfo fileInfo = myShapefile.Info;
-                InfoGrid.BindingContext = fileInfo;
+                InfoList.BindingContext = fileInfo;
 
-                // Read the thumbnail image data into a byte array
+                // Read the thumbnail image data into a byte array.
                 Stream imageStream = await fileInfo.Thumbnail.GetEncodedBufferAsync();
                 byte[] imageData = new byte[imageStream.Length];
                 imageStream.Read(imageData, 0, imageData.Length);
 
-                // Create a new image source from the thumbnail data
+                // Create a new image source from the thumbnail data.
                 ImageSource streamImageSource = ImageSource.FromStream(() => new MemoryStream(imageData));
 
-                // Create a new image to display the thumbnail
-                Image image = new Image()
+                // Create a new image to display the thumbnail.
+                var image = new Image()
                 {
                     Source = streamImageSource,
                     Margin = new Thickness(10)
                 };
 
-                // Show the thumbnail image in a UI control
+                // Show the thumbnail image in a UI control.
                 ShapefileThumbnailImage.Source = image.Source;
 
-                // Create a feature layer to display the shapefile
-                FeatureLayer newFeatureLayer = new FeatureLayer(myShapefile);
+                // Create a feature layer to display the shapefile.
+                var newFeatureLayer = new FeatureLayer(myShapefile);
                 await newFeatureLayer.LoadAsync();
 
-                // Zoom the map to the extent of the shapefile
+                // Zoom the map to the extent of the shapefile.
                 MyMapView.SpatialReferenceChanged += async (s, e) =>
                 {
                     await MyMapView.SetViewpointGeometryAsync(newFeatureLayer.FullExtent);
                 };
 
-                // Add the feature layer to the map
+                // Add the feature layer to the map.
                 streetMap.OperationalLayers.Add(newFeatureLayer);
 
-                // Show the map in the MapView
+                // Show the map in the MapView.
                 MyMapView.Map = streetMap;
             }
             catch (Exception e)
             {
                 await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
-        }
-
-        private void ShowMetadataClicked(object sender, System.EventArgs e)
-        {
-            // Toggle the visibility of the metadata panel
-            MetadataScrollView.IsVisible = !MetadataScrollView.IsVisible;
         }
 
         private static string GetShapefilePath()


### PR DESCRIPTION
# Description

Not all of the shapefile metadata is visible. The description is missing.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
