### PR TITLE
`AddClusteringFeatureReductionToAPointFeatureLayer`: Unchecked event subscription

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
@@ -39,7 +39,8 @@
                                   Grid.Column="1"
                                   VerticalAlignment="Center"
                                   Checked="DisplayLabelsCheckBox_Checked"
-                                  IsChecked="false" />
+                                  IsChecked="false"
+                                  Unchecked="DisplayLabelsCheckBox_Checked" />
                         <TextBlock Grid.Row="1"
                                    Grid.Column="0"
                                    VerticalAlignment="Center">

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
@@ -31,7 +31,8 @@
                                   Grid.Column="1"
                                   VerticalAlignment="Center"
                                   Checked="DisplayLabelsCheckBox_CheckedChanged"
-                                  IsChecked="false" />
+                                  IsChecked="false"
+                                  Unchecked="DisplayLabelsCheckBox_CheckedChanged" />
                         <TextBlock Grid.Row="1"
                                    Grid.Column="0"
                                    VerticalAlignment="Center">


### PR DESCRIPTION
# Description

Subscribe to the unchecked event for the display label checkbox for WPF and WinUI implementations of `AddClusteringFeatureReduction`. Not in issue for .NET MAUI implementation since we're subscribed to the CheckedChanged event.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files