### PR TITLE
`ManageFeatures`: prevent `NullReferenceException` when editing back-to-back

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml.cs
@@ -235,8 +235,8 @@ namespace ArcGIS.Samples.ManageFeatures
 
         private async void DamageType_Changed(object sender, EventArgs e)
         {
-            // Skip if nothing is selected.
-            if (DamageTypePicker.SelectedIndex == -1) return;
+            // Skip if nothing is selected or selected feature is null.
+            if (DamageTypePicker.SelectedIndex == -1 || _selectedFeature == null) return;
 
             try
             {


### PR DESCRIPTION
# Description

For the .NET MAUI implementation of `ManageFeatures`, prevent a `NullReferenceException` when performing back-to-back edit damage type operations. This is only an issue on iOS and MacCatalyst. With bug fix, if user attempts to edit back-to-back without de-selecting the feature, an alert will not appear saying that the edit was successful. Alerts only appear when edits were successful. When de-selecting the edited feature, and re-selecting the feature, it will show the damage type as to what had been successfully edited, not the last thing actually selected. This bug fix enforces consistent behavior on all .NET MAUI platforms - to make another edit, you have to select the feature again.

Repro steps (without bug fix):

1. Open ManageFeatures on iOS or MacCatalyst.
2. Select the edit operation.
3. Select a feature.
4. Select a new damage type.
5. After alert appears, hit "OK" to close.
6. Hit "Done" to close the picker. Edit operation worked as intended.
7. Repeat steps 4 and 5.
8. Again, repeat steps 4 and 5, intentionally not hitting "Done" between edit operations.
9. Notice the exception in the alert.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
