### PR TITLE
Add Grid resources to remaining .NET MAUI samples

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
@@ -14,11 +14,7 @@
                     <Label Margin="0,0,0,10"
                            FontSize="Small"
                            Text="Clustering properties" />
-                    <Grid Grid.RowDefinitions="auto,auto,auto,auto">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="{OnPlatform Default=*, iOS=150}" />
-                        </Grid.ColumnDefinitions>
+                    <Grid Grid.RowDefinitions="auto,auto,auto,auto" ColumnDefinitions="auto,*">
                         <Label Grid.Row="0"
                                Grid.Column="0"
                                Text="Display Labels"

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
@@ -14,7 +14,7 @@
                     <Label Margin="0,0,0,10"
                            FontSize="Small"
                            Text="Clustering properties" />
-                    <Grid Grid.RowDefinitions="auto,auto,auto,auto" ColumnDefinitions="auto,*">
+                    <Grid ColumnDefinitions="auto,*" RowDefinitions="auto,auto,auto,auto">
                         <Label Grid.Row="0"
                                Grid.Column="0"
                                Text="Display Labels"

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddClusteringFeatureReductionToAPointFeatureLayer/AddClusteringFeatureReductionToAPointFeatureLayer.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriTK="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, *">
+    <Grid Style="{DynamicResource EsriSampleContainer}">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
             <VerticalStackLayout>

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
-    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, *">
+    <Grid Style="{DynamicResource EsriSampleContainer}">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border x:Name="MainUI"
                 Style="{DynamicResource EsriSampleControlPanel}"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayPointsUsingClusteringFeatureReduction/DisplayPointsUsingClusteringFeatureReduction.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayPointsUsingClusteringFeatureReduction/DisplayPointsUsingClusteringFeatureReduction.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
              xmlns:esriTK="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui">
-    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, *">
+    <Grid Style="{DynamicResource EsriSampleContainer}">
         <esri:MapView x:Name="MyMapView"
                       GeoViewTapped="MyMapView_GeoViewTapped"
                       Style="{DynamicResource EsriSampleGeoView}" />


### PR DESCRIPTION
# Description

Add the sample container resource to a few `Grid`s to fix UI issues on mobile. Also adjust the column definition to account for this change.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
