### PR TITLE
Change local data path on Windows

### DIFF
--- a/src/Samples.Shared/Managers/ApiKeyManager.cs
+++ b/src/Samples.Shared/Managers/ApiKeyManager.cs
@@ -164,7 +164,7 @@ namespace ArcGIS.Samples.Shared.Managers
 #else
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #endif
-            string sampleDataFolder = Path.Combine(appDataFolder, "ArcGISSampleData");
+            string sampleDataFolder = Path.Combine(appDataFolder, "ESRI", "dotnetSamples", "Data");
 
             if (!Directory.Exists(sampleDataFolder)) { Directory.CreateDirectory(sampleDataFolder); }
 

--- a/src/Samples.Shared/Managers/ApiKeyManager.cs
+++ b/src/Samples.Shared/Managers/ApiKeyManager.cs
@@ -25,6 +25,7 @@ using System.Text;
 
 #endif
 
+using ArcGIS.Samples.Managers;
 using Map = Esri.ArcGISRuntime.Mapping.Map;
 
 namespace ArcGIS.Samples.Shared.Managers
@@ -115,7 +116,7 @@ namespace ArcGIS.Samples.Shared.Managers
 #if __IOS__
             try
             {
-                return await Task.FromResult(Encoding.Default.GetString(Decrypt(File.ReadAllBytes(Path.Combine(GetDataFolder(), _apiKeyFileName)))));
+                return await Task.FromResult(Encoding.Default.GetString(Decrypt(File.ReadAllBytes(Path.Combine(DataManager.GetDataFolder(), _apiKeyFileName)))));
             }
             catch (Exception ex)
             {
@@ -125,7 +126,7 @@ namespace ArcGIS.Samples.Shared.Managers
 #elif ANDROID
             return await SecureStorage.GetAsync(_apiKeyFileName);
 #else
-            return await Task.FromResult(Encoding.Default.GetString(Unprotect(File.ReadAllBytes(Path.Combine(GetDataFolder(), _apiKeyFileName)))));
+            return await Task.FromResult(Encoding.Default.GetString(Unprotect(File.ReadAllBytes(Path.Combine(DataManager.GetDataFolder(), _apiKeyFileName)))));
 #endif
         }
 
@@ -134,7 +135,7 @@ namespace ArcGIS.Samples.Shared.Managers
             try
             {
 #if __IOS__
-                File.WriteAllBytes(Path.Combine(GetDataFolder(), _apiKeyFileName), Encrypt(Encoding.Default.GetBytes(Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.ApiKey)));
+                File.WriteAllBytes(Path.Combine(DataManager.GetDataFolder(), _apiKeyFileName), Encrypt(Encoding.Default.GetBytes(Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.ApiKey)));
                 return true;
 #elif ANDROID
 
@@ -143,7 +144,7 @@ namespace ArcGIS.Samples.Shared.Managers
 
 #else
 
-                File.WriteAllBytes(Path.Combine(GetDataFolder(), _apiKeyFileName), Protect(Encoding.Default.GetBytes(Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.ApiKey)));
+                File.WriteAllBytes(Path.Combine(DataManager.GetDataFolder(), _apiKeyFileName), Protect(Encoding.Default.GetBytes(Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.ApiKey)));
                 return true;
 
 #endif
@@ -153,22 +154,6 @@ namespace ArcGIS.Samples.Shared.Managers
                 Debug.WriteLine(ex.Message);
                 return false;
             }
-        }
-
-        internal static string GetDataFolder()
-        {
-#if NETFX_CORE
-            string appDataFolder = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
-#elif __ANDROID__ && !NETCOREAPP
-            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-#else
-            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-#endif
-            string sampleDataFolder = Path.Combine(appDataFolder, "ESRI", "dotnetSamples", "Data");
-
-            if (!Directory.Exists(sampleDataFolder)) { Directory.CreateDirectory(sampleDataFolder); }
-
-            return sampleDataFolder;
         }
 
 #if !__IOS__ && !__ANDROID__

--- a/src/Samples.Shared/Managers/DataManager.cs
+++ b/src/Samples.Shared/Managers/DataManager.cs
@@ -248,7 +248,7 @@ namespace ArcGIS.Samples.Managers
 #else
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #endif
-            string sampleDataFolder = Path.Combine(appDataFolder, "ArcGISSampleData");
+            string sampleDataFolder = Path.Combine(appDataFolder, "ESRI", "dotnetSamples", "Data");
 
             if (!Directory.Exists(sampleDataFolder)) { Directory.CreateDirectory(sampleDataFolder); }
 

--- a/src/Samples.Shared/Managers/DataManager.cs
+++ b/src/Samples.Shared/Managers/DataManager.cs
@@ -237,7 +237,7 @@ namespace ArcGIS.Samples.Managers
         /// <summary>
         /// Gets the data folder where locally provisioned data is stored.
         /// </summary>
-        internal static string GetDataFolder()
+        public static string GetDataFolder()
         {
 #if NETFX_CORE
             string appDataFolder = Windows.Storage.ApplicationData.Current.LocalFolder.Path;

--- a/src/Samples.Shared/Managers/SampleManager.cs
+++ b/src/Samples.Shared/Managers/SampleManager.cs
@@ -307,7 +307,7 @@ namespace ArcGIS.Samples.Managers
         {
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-            string sampleDataFolder = Path.Combine(appDataFolder, "ArcGISRuntimeFavorites");
+            string sampleDataFolder = Path.Combine(appDataFolder, "ESRI", "dotnetSamples", "Favorites");
 
             if (!Directory.Exists(sampleDataFolder)) { Directory.CreateDirectory(sampleDataFolder); }
 

--- a/src/Samples.Shared/Managers/ScreenshotManager.cs
+++ b/src/Samples.Shared/Managers/ScreenshotManager.cs
@@ -78,7 +78,7 @@ namespace ArcGIS.Samples.Shared.Managers
         {
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-            string screenshotSettingsFolder = Path.Combine(appDataFolder, "ArcGISRuntimeScreenshots");
+            string screenshotSettingsFolder = Path.Combine(appDataFolder, "ESRI", "dotnetSamples", "ScreenshotSettings");
 
             if (!Directory.Exists(screenshotSettingsFolder)) { Directory.CreateDirectory(screenshotSettingsFolder); }
 


### PR DESCRIPTION
# Description

Nest all local data paths on Windows following company/product convention.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
