### PR TITLE
Upgrade MAUI sample viewer to use MAUI 8.0.6

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,8 +31,8 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Upgrade MAUI sample viewer to 8.0.6.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
