### PR TITLE
Address resizing issue on MAUI Windows and sample opening issue on Android

### DIFF
--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -98,6 +98,12 @@ namespace ArcGIS.ViewModels
                 SamplesItems.Remove(sample);
             }
         }
+
+        [RelayCommand]
+        void SampleSelected(SampleViewModel sampleViewModel)
+        {
+            _ = SampleLoader.LoadSample(sampleViewModel.SampleObject);
+        }
     }
 
     public partial class SampleViewModel : ObservableObject

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
@@ -20,13 +20,12 @@
         <converters:SampleToBitmapConverter x:Key="SampleToBitmapConverter" />
         <converters:BoolToFavoriteGlyphConverter x:Key="BoolToFavoriteGlyphConverter" />
     </ContentPage.Resources>
-    <CollectionView BackgroundColor="Transparent"
-                    x:Name="SamplesCollection"
-                    ItemsSource="{Binding SamplesItems}"
-                    SelectionChanged="CollectionView_SelectionChanged"
-                    SelectionMode="Single">
+    <CollectionView x:Name="SamplesCollection"
+                    BackgroundColor="Transparent"
+                    ItemsSource="{Binding SamplesItems}">
         <CollectionView.ItemsLayout>
-            <GridItemsLayout HorizontalItemSpacing="5"
+            <GridItemsLayout x:Name="SamplesGridItemsLayout"
+                             HorizontalItemSpacing="5"
                              Orientation="Vertical"
                              Span="{OnPlatform Default=4,
                                                iOS=1,
@@ -39,8 +38,11 @@
                     <Border.GestureRecognizers>
                         <PointerGestureRecognizer PointerEntered="PointerGestureRecognizer_PointerEntered" />
                         <PointerGestureRecognizer PointerExited="PointerGestureRecognizer_PointerExited" />
+                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:CategoryViewModel}}, Path=SampleSelectedCommand}"
+                                              CommandParameter="{Binding .}"
+                                              NumberOfTapsRequired="1" />
                     </Border.GestureRecognizers>
-                    <Grid WidthRequest="{Binding SampleImageWidth, Mode=OneTime}" >
+                    <Grid WidthRequest="{Binding SampleImageWidth, Mode=OneTime}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                             <RowDefinition Height="45" />

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
@@ -26,15 +26,21 @@ public partial class CategoryPage : ContentPage
         BindingContext = _viewModel;
 
         WeakReferenceMessenger.Default.Register<string>(this, (message, category) => ScrollToTop());
-
+#if !ANDROID
         SizeChanged += (s, e) =>
         {
+#if IOS || MACCATALYST
             var numberOfColumns = Math.Floor(Width / _viewModel.SampleImageWidth);
             var layout = new GridItemsLayout((int)numberOfColumns, ItemsLayoutOrientation.Vertical);
             layout.HorizontalItemSpacing = 5;
             layout.VerticalItemSpacing = 5;
             SamplesCollection.ItemsLayout = layout;
+#elif WINDOWS
+            var numberOfColumns = Math.Floor(Width / _viewModel.SampleImageWidth);
+            SamplesGridItemsLayout.Span = (int)numberOfColumns;
+#endif
         };
+#endif
 
     }
 
@@ -91,21 +97,6 @@ public partial class CategoryPage : ContentPage
         if (firstItem != null)
         {
             SamplesCollection.ScrollTo(firstItem, null, ScrollToPosition.Start);
-        }
-    }
-
-    private void CollectionView_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        try
-        {
-            var selectedCategory = e.CurrentSelection.FirstOrDefault() as SampleViewModel;
-
-            _ = SampleLoader.LoadSample(selectedCategory.SampleObject);
-
-        }
-        catch (Exception ex)
-        {
-            Debug.Write(ex.ToString());
         }
     }
 }


### PR DESCRIPTION
# Description

The pointer entered/exited gesture recognizer seems to prevent the selection changed event firing for a collection view on Android. Reworked the sample opening process to account for this. 

MacCatalyst and iOS throw null reference errors when attempting to update an existing GridItemsLayout and instead need to have a completely new layout added dynamically. This workflow causes the Windows implementation to be sluggish. Implemented platform specific changes to improve Windows performance.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
