### PR TITLE
Fix issue with MAUI Network Analysis sample source code not appearing

### DIFF
--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -275,8 +275,8 @@ namespace ArcGIS
             // Get all files in the samples folder.
             var fileNames = new List<string>
             {
-                $"Samples/{sampleInfo.Category}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml.cs",
-                $"Samples/{sampleInfo.Category}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml",
+                $"Samples/{sampleInfo.Category.Replace(" ","")}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml.cs",
+                $"Samples/{sampleInfo.Category.Replace(" ","")}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml",
             };
 
             // Add every .cs and .xaml file in the directory of the sample.


### PR DESCRIPTION
# Description

The category Network Analysis has a space but the folder does not.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
