### PR TITLE
Source code viewer: copy functionality, updated UI

### DIFF
--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml
@@ -42,7 +42,7 @@
                             FontFamily="calcite-ui-icons-24"
                             FontSize="20"
                             HorizontalOptions="End"
-                            Text="&#xe0d9;"
+                            Text="&#xe0a6;"
                             ToolTipProperties.Text="Copy code to clipboard" />
                 </Grid>
                 <Border x:Name="SourceCodeViewContainer" VerticalOptions="FillAndExpand" />

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml
@@ -22,15 +22,29 @@
         <Border x:Name="SampleDetailPage" IsVisible="false" />
         <Border x:Name="SourceCodePage" IsVisible="false">
             <StackLayout>
-                <StackLayout Orientation="Horizontal">
-                    <Button Margin="5"
-                            Clicked="FileChange_Clicked"
-                            Text="Change file" />
-                    <Label x:Name="CurrentFileLabel"
-                           Margin="5"
-                           Text=""
+                <Grid BackgroundColor="{AppThemeBinding Dark={StaticResource Dark}, Light={StaticResource Light}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="{OnIdiom Phone=5*, Default=Auto}" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Margin="5"
+                           FontAttributes="Bold"
+                           Text="View file:"
                            VerticalOptions="Center" />
-                </StackLayout>
+                    <Picker x:Name="FilePicker"
+                            Grid.Column="1"
+                            SelectedIndexChanged="FilePicker_SelectedIndexChanged" />
+                    <Button Grid.Column="2"
+                            Background="Transparent"
+                            BorderWidth="0"
+                            Clicked="CopyCodeButton_Clicked"
+                            FontFamily="calcite-ui-icons-24"
+                            FontSize="20"
+                            HorizontalOptions="End"
+                            Text="&#xe0d9;"
+                            ToolTipProperties.Text="Copy code to clipboard" />
+                </Grid>
                 <Border x:Name="SourceCodeViewContainer" VerticalOptions="FillAndExpand" />
             </StackLayout>
         </Border>

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -277,8 +277,8 @@ namespace ArcGIS
             // Get all files in the samples folder.
             var fileNames = new List<string>
             {
-                $"Samples/{sampleInfo.Category}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml.cs",
-                $"Samples/{sampleInfo.Category}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml",
+                $"Samples/{sampleInfo.Category.Replace(" ","")}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml.cs",
+                $"Samples/{sampleInfo.Category.Replace(" ","")}/{sampleInfo.FormalName}/{sampleInfo.FormalName}.xaml",
             };
 
             // Add every .cs and .xaml file in the directory of the sample.

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -8,11 +8,11 @@
 // language governing permissions and limitations under the License.
 
 #if WINDOWS
-        using uiXaml =  Microsoft.UI.Xaml;
-        using System.Drawing;
-        using ArcGIS.Samples.Shared.Managers;
-        using System.Text.RegularExpressions;
-        using Microsoft.Maui.Graphics;
+using uiXaml = Microsoft.UI.Xaml;
+using System.Drawing;
+using ArcGIS.Samples.Shared.Managers;
+using System.Text.RegularExpressions;
+using Microsoft.Maui.Graphics;
 #endif
 
 using ArcGIS.Samples.Managers;
@@ -35,12 +35,14 @@ namespace ArcGIS
         private ContentPage _sampleContent;
         private Assembly _assembly;
         private int _lastViewedFileIndex = 0;
+
         // single-instance webviews reused on each view, to avoid a memory leak in webview
-        static WebView DescriptionView = new WebView();
-        static WebView SourceCodeView = new WebView();
+        private static WebView DescriptionView = new WebView();
+        private static WebView SourceCodeView = new WebView();
 
-        SampleInfo _sample;
+        private SampleInfo _sample;
 
+        private SourceCodeFile _selectedFile;
         public ObservableCollection<SourceCodeFile> SourceFiles { get; } = new ObservableCollection<SourceCodeFile>();
 
         public SamplePage(SampleInfo sample)
@@ -71,7 +73,7 @@ namespace ArcGIS
             {
                 var screenshotToolbarItem = new ToolbarItem();
                 screenshotToolbarItem.Clicked += ScreenshotButton_Clicked;
-                screenshotToolbarItem.IconImageSource="camera.png";
+                screenshotToolbarItem.IconImageSource = "camera.png";
                 screenshotToolbarItem.Text = "Screenshot";
                 ToolbarItems.Insert(0, screenshotToolbarItem);
 
@@ -134,7 +136,7 @@ namespace ArcGIS
         }
 
         private async void LoadSampleData(SampleInfo sampleInfo)
-        { 
+        {
             // Set up the description page.
             try
             {
@@ -152,7 +154,6 @@ namespace ArcGIS
             try
             {
                 LoadSourceCode(sampleInfo);
-
             }
             catch (Exception ex)
             {
@@ -233,6 +234,7 @@ namespace ArcGIS
         }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
         public static async Task<Stream> LoadImageStreamAsync(string file)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
@@ -259,7 +261,7 @@ namespace ArcGIS
                     return stream;
             }
 #else
-		    try
+            try
             {
                 return await FileSystem.Current.OpenAppPackageFileAsync(file);
             }
@@ -305,6 +307,12 @@ namespace ArcGIS
                     }
                 }
             }
+
+            FilePicker.Items.Clear();
+            FilePicker.ItemsSource = SourceFiles;
+
+            // Use the file name as the display name for the picker
+            FilePicker.ItemDisplayBinding = new Binding("FileName");
         }
 
         private void Webview_Navigating(object sender, WebNavigatingEventArgs e)
@@ -346,12 +354,14 @@ namespace ArcGIS
         {
             if (SourceFiles.Any())
             {
-                SelectFile(SourceFiles[_lastViewedFileIndex].Name);
+                _selectedFile = SourceFiles[_lastViewedFileIndex];
+                FilePicker.SelectedIndex = _lastViewedFileIndex;
             }
 
             SourceCodePage.IsVisible = true;
             SampleDetailPage.IsVisible = SampleContentPage.IsVisible = false;
         }
+
         private async void GitHubButton_Clicked(object sender, EventArgs e)
         {
             try
@@ -359,32 +369,16 @@ namespace ArcGIS
                 Uri uri = new Uri(SampleManager.Current.SelectedSample.GetGitHubUrl());
                 await Browser.Default.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // An unexpected error occurred. No browser may be installed on the device.
             }
         }
 
-        private async void FileChange_Clicked(object sender, EventArgs e)
+        private void CopyCodeButton_Clicked(object sender, EventArgs e)
         {
-            try
-            {
-                string[] fileList = SourceFiles.Select(s => s.Name.Split('/').Last()).ToArray();
-                string result = await Application.Current.MainPage.DisplayActionSheet("Choose file:", "Cancel", null, fileList);
-
-                _lastViewedFileIndex = fileList.ToList().IndexOf(result);
-
-                if (fileList.Contains(result))
-                {
-                    SelectFile(SourceFiles.FirstOrDefault(s => s.Name.Split("/").Last().Equals(result)).Name);
-                }
-            }
-            // No need to handle any cancellation.
-            catch
-            {
-            }
+            Clipboard.SetTextAsync(_selectedFile.SourceCode);
         }
-
 
 #if WINDOWS
         private void ScreenshotButton_Clicked(object sender, EventArgs e)
@@ -433,9 +427,8 @@ namespace ArcGIS
             {
                 Console.WriteLine($"Error saving screenshot: {ex.Message}");
             }
-        }  
+        }
 #endif
-
 
         private void SelectFile(string fileName)
         {
@@ -443,8 +436,12 @@ namespace ArcGIS
             {
                 Html = SourceFiles.FirstOrDefault(s => s.Name == fileName).HtmlContent,
             };
+        }
 
-            CurrentFileLabel.Text = fileName.Split('/').Last();
+        private void FilePicker_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            _selectedFile = SourceFiles[FilePicker.SelectedIndex];
+            SelectFile(_selectedFile.Name);
         }
     }
 
@@ -467,8 +464,11 @@ namespace ArcGIS
 
         private string _path;
         private string _fullContent;
+        public string SourceCode { get; set; }
 
         public string Path => _path;
+
+        public string FileName => System.IO.Path.GetFileName(_path);
 
         public string Name
         {
@@ -491,27 +491,28 @@ namespace ArcGIS
 
             _ = LoadContent();
         }
+
         private async Task LoadContent()
         {
             try
             {
-                string baseContent = string.Empty;
+                string baseContent = SourceCode = string.Empty;
                 var assembly = Assembly.GetExecutingAssembly();
 #if __ANDROID__
                 if (_path.EndsWith(".xaml"))
                 {
                     var fileName = _path.Split('/').Last();
                     var xamlPath = assembly.GetManifestResourceNames().Single(n => n.EndsWith($"{fileName}"));
-                    baseContent = new StreamReader(assembly.GetManifestResourceStream(xamlPath)).ReadToEnd();
+                    SourceCode = baseContent = new StreamReader(assembly.GetManifestResourceStream(xamlPath)).ReadToEnd();
                 }
                 else
                 {
                     using Stream fileStream = await FileSystem.Current.OpenAppPackageFileAsync(_path).ConfigureAwait(false);
-                    baseContent = new StreamReader(fileStream).ReadToEnd();
+                    SourceCode = baseContent = new StreamReader(fileStream).ReadToEnd();
                 }
 #else
                 using Stream fileStream = await FileSystem.Current.OpenAppPackageFileAsync(_path).ConfigureAwait(false);
-                baseContent = new StreamReader(fileStream).ReadToEnd();
+                SourceCode = baseContent = new StreamReader(fileStream).ReadToEnd();
 #endif
                 // > and < characters will be incorrectly parsed by the html.
                 baseContent = baseContent.Replace("<", "&lt;").Replace(">", "&gt;");

--- a/src/WPF/WPF.Viewer/Resources/ControlStyles.xaml
+++ b/src/WPF/WPF.Viewer/Resources/ControlStyles.xaml
@@ -291,11 +291,4 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
-
-    <Style x:Key="ContextMenuItemIcon" TargetType="TextBlock">
-        <Setter Property="FontSize" Value="17" />
-        <Setter Property="FontFamily" Value="pack://application:,,,/Resources/Fonts/#calcite-ui-icons-24" />
-        <Setter Property="Text" Value="&#xe0d9;" />
-        <Setter Property="Background" Value="Transparent" />
-    </Style>
 </ResourceDictionary>

--- a/src/WPF/WPF.Viewer/Resources/ControlStyles.xaml
+++ b/src/WPF/WPF.Viewer/Resources/ControlStyles.xaml
@@ -291,4 +291,11 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <Style x:Key="ContextMenuItemIcon" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="17" />
+        <Setter Property="FontFamily" Value="pack://application:,,,/Resources/Fonts/#calcite-ui-icons-24" />
+        <Setter Property="Text" Value="&#xe0d9;" />
+        <Setter Property="Background" Value="Transparent" />
+    </Style>
 </ResourceDictionary>

--- a/src/WPF/WPF.Viewer/SourceCodeViewer.xaml
+++ b/src/WPF/WPF.Viewer/SourceCodeViewer.xaml
@@ -5,22 +5,47 @@
              Background="{StaticResource PrimaryBackgroundColor}">
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <TabControl ItemsSource="{Binding SourceFiles, Mode=OneWay}" SelectedItem="{Binding SelectedSourceFile, Mode=TwoWay}">
-            <TabControl.ContentTemplate>
-                <DataTemplate>
-                    <WebBrowser viewer:BrowserBehavior.Html="{Binding HtmlContent}" />
-                </DataTemplate>
-            </TabControl.ContentTemplate>
-            <TabControl.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Name}" />
-                </DataTemplate>
-            </TabControl.ItemTemplate>
-        </TabControl>
-        <StatusBar Grid.Row="1">
+        <Grid Background="{StaticResource SecondaryBackgroundColor}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Margin="15,5,5,5"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       FontWeight="Bold"
+                       Text="View file:" />
+            <ComboBox Grid.Column="1"
+                      Width="400"
+                      Margin="5"
+                      VerticalAlignment="Center"
+                      ItemsSource="{Binding SourceFiles, Mode=OneWay}"
+                      SelectedItem="{Binding SelectedSourceFile, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button x:Name="CopyCodeButton"
+                    Grid.Column="2"
+                    Margin="5,5,20,5"
+                    HorizontalAlignment="Right"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Click="CopyCodeButton_Click"
+                    Content="&#xe0d9;"
+                    FontFamily="pack://application:,,,/Resources/Fonts/#calcite-ui-icons-24"
+                    FontSize="30"
+                    ToolTip="Copy code to clipboard" />
+        </Grid>
+        <WebBrowser Grid.Row="1" viewer:BrowserBehavior.Html="{Binding SelectedSourceFile.HtmlContent}" />
+        <StatusBar Grid.Row="2">
             <StatusBarItem>
                 <TextBlock Text="{Binding SelectedSourceFile.Path, Mode=OneWay}" />
             </StatusBarItem>

--- a/src/WPF/WPF.Viewer/SourceCodeViewer.xaml
+++ b/src/WPF/WPF.Viewer/SourceCodeViewer.xaml
@@ -39,7 +39,7 @@
                     Background="Transparent"
                     BorderThickness="0"
                     Click="CopyCodeButton_Click"
-                    Content="&#xe0d9;"
+                    Content="&#xe0a6;"
                     FontFamily="pack://application:,,,/Resources/Fonts/#calcite-ui-icons-24"
                     FontSize="30"
                     ToolTip="Copy code to clipboard" />

--- a/src/WPF/WPF.Viewer/SourceCodeViewer.xaml.cs
+++ b/src/WPF/WPF.Viewer/SourceCodeViewer.xaml.cs
@@ -7,7 +7,9 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGIS.Samples.Desktop;
 using ArcGIS.Samples.Managers;
+using ArcGIS.Samples.Shared.Models;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -70,6 +72,7 @@ namespace ArcGIS.WPF.Viewer
             }
 
             SelectedSourceFile = SourceFiles[0];
+
         }
 
         public class SourceCodeFile
@@ -111,6 +114,8 @@ namespace ArcGIS.WPF.Viewer
                 }
             }
 
+            public string SourceCode { get; set; }
+
             public SourceCodeFile(string sourceFilePath)
             {
                 _path = sourceFilePath;
@@ -126,7 +131,7 @@ namespace ArcGIS.WPF.Viewer
                 // Source code of the file.
                 try
                 {
-                    string baseContent = File.ReadAllText(_path);
+                    string baseContent = SourceCode = File.ReadAllText(_path);
 
                     // Set the type of highlighting for the source file.
                     string codeClass = _path.EndsWith(".xaml") ? "xml" : "csharp";
@@ -147,6 +152,11 @@ namespace ArcGIS.WPF.Viewer
                     System.Diagnostics.Debug.WriteLine(ex);
                 }
             }
+        }
+
+        private void CopyCodeButton_Click(object sender, RoutedEventArgs e)
+        {
+            Clipboard.SetText(_selectedFile.SourceCode);
         }
     }
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/SourceCodeViewer.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/SourceCodeViewer.xaml
@@ -2,14 +2,50 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Background="{StaticResource PrimaryBackgroundColor}">
+    <UserControl.Resources>
+        <FontFamily x:Key="Calcite">/Resources/Fonts/calcite-ui-icons-24.ttf#calcite-ui-icons-24</FontFamily>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="40" />
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TabView x:Name="Tabs"
-                 Grid.Row="0"
-                 IsAddTabButtonVisible="False" />
+        <Grid Background="{StaticResource SecondaryBackgroundColor}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Margin="15,5,5,5"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Text="View file:" />
+            <ComboBox Grid.Column="1"
+                      Width="400"
+                      Margin="5"
+                      VerticalAlignment="Center"
+                      DataContext="{x:Bind}"
+                      ItemsSource="{Binding SourceFiles, Mode=OneWay}"
+                      SelectedItem="{Binding SelectedSourceFile, Mode=TwoWay}"
+                      SelectionChanged="File_SelectionChanged">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button x:Name="CopyCodeButton"
+                    Grid.Column="2"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Click="CopyCodeButton_Click"
+                    Content="&#xe0d9;"
+                    FontFamily="{StaticResource Calcite}"
+                    FontSize="30"
+                    ToolTipService.ToolTip="Copy code to clipboard" />
+        </Grid>
         <WebView2 x:Name="WebView" Grid.Row="1" />
     </Grid>
 </UserControl>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/SourceCodeViewer.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/SourceCodeViewer.xaml
@@ -41,7 +41,7 @@
                     Background="Transparent"
                     BorderThickness="0"
                     Click="CopyCodeButton_Click"
-                    Content="&#xe0d9;"
+                    Content="&#xe0a6;"
                     FontFamily="{StaticResource Calcite}"
                     FontSize="30"
                     ToolTipService.ToolTip="Copy code to clipboard" />


### PR DESCRIPTION
# Description

Adds a new button to the source code viewer for copying the code to system clipboard. Updates the UI so all source code viewers share the same code viewer design. Fixes an issue with source code viewer showing network analysis sample source code.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
