### PR TITLE
Fix MAUI sample viewer screenshot tool

### DIFF
--- a/src/MAUI/Maui.Samples/Views/ScreenshotView.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/ScreenshotView.xaml.cs
@@ -38,12 +38,6 @@ public partial class ScreenshotView : ContentView
     {
         ScreenshotSettings screenshotSettings = new ScreenshotSettings();
 
-        // Do not overwrite the saved WinUI setting.
-        if (ScreenshotManager.ScreenshotSettings.ScaleFactor.HasValue)
-        {
-            screenshotSettings.ScaleFactor = ScreenshotManager.ScreenshotSettings.ScaleFactor.Value;
-        }
-
         screenshotSettings.ScreenshotEnabled = ScreenshotEnabledCheckBox.IsChecked ? ScreenshotEnabledCheckBox.IsChecked : false;
         screenshotSettings.SourcePath = SourcePathEntry.Text;
 
@@ -63,6 +57,15 @@ public partial class ScreenshotView : ContentView
         else
         {
             screenshotSettings.Height = null;
+        }
+
+        if (double.TryParse(ScaleFactorEntry.Text, out double scaleFactor))
+        {
+            screenshotSettings.ScaleFactor = scaleFactor;
+        }
+        else
+        {
+            screenshotSettings.ScaleFactor = null;
         }
 
         ScreenshotManager.SaveScreenshotSettings(screenshotSettings);


### PR DESCRIPTION
# Description

The screenshot tool was not saving data in the MAUI sample viewer unless the WinUI value had already been set via the WinUI sample viewer. This pattern is no longer necessary and has been removed.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
