### PR TITLE
Replace .NETFramework.csproj in samplegen.py

### DIFF
--- a/tools/sample_generator/samplegen.py
+++ b/tools/sample_generator/samplegen.py
@@ -24,7 +24,7 @@ def get_proj_file(platform, sample_root):
     '''
     basepath = get_platform_root(platform, sample_root)
     if (platform == "WPF"):
-        return os.path.join(basepath, "ArcGIS.WPF.Viewer.NetFramework.csproj")
+        return os.path.join(basepath, "ArcGIS.WPF.Viewer.Net.csproj")
     if (platform == "WinUI"):
         return os.path.join(basepath, "ArcGIS.WinUI.Viewer.csproj")
     if (platform == "MAUI"):


### PR DESCRIPTION
# Description

Don't use the .NETFramework .csproj which doesn't exist anymore in our sample generator script. Use the existing .csproj instead. Found this when creating `ValidateUtilityNetworkTopology` sample and subsequently tested my fix.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix