### PR TITLE
Duplicate sample pages fiX

### DIFF
--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -102,7 +102,8 @@ namespace ArcGIS.ViewModels
         [RelayCommand]
         void SampleSelected(SampleViewModel sampleViewModel)
         {
-            _ = SampleLoader.LoadSample(sampleViewModel.SampleObject);
+            if(SampleManager.Current.SelectedSample == null)
+                _ = SampleLoader.LoadSample(sampleViewModel.SampleObject);
         }
     }
 

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -127,6 +127,8 @@ namespace ArcGIS
 
                 if (_sampleContent is IDisposable disposableSample) disposableSample.Dispose();
                 if (_sampleContent is IARSample ARSample) ARSample.StopAugmentedReality();
+
+                SampleManager.Current.SelectedSample = null;
             }
         }
 


### PR DESCRIPTION
# Description

Fixes an issue where rapidly tapping a sample collection view item would 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
