### PR TITLE
Fix download icon in dark mode (Windows)

### DIFF
--- a/src/MAUI/Maui.Samples/Views/SettingsPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/SettingsPage.xaml
@@ -21,7 +21,7 @@
         <ToolbarItem
             x:Name="OfflineDataButton"
             Clicked="OfflineDataButton_Clicked"
-            IconImageSource="download.png"
+            IconImageSource="downloaddark.png"
             Text="Offline data" />
         <ToolbarItem
             x:Name="ApiKeyButton"


### PR DESCRIPTION
# Description

The current dark mode icon is drawn in black. The background is also black. Use the dark mode icon for this settings icon.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
