### PR TITLE
Prevent duplicate settings windows at once

### DIFF
--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -35,6 +35,7 @@ namespace ArcGIS.Samples.Desktop
         private List<TreeViewItem> _samples;
         private System.Windows.Forms.Timer _delaySearchTimer;
         private const int _delayedTextChangedTimeout = 500;
+        private bool _settingsWindowOpen;
 
         private List<string> _namedUserSamples = new List<string> {
             "AuthorMap",
@@ -466,6 +467,8 @@ namespace ArcGIS.Samples.Desktop
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
+            if (_settingsWindowOpen) return;
+            _settingsWindowOpen = true;
             SettingsWindow settingsWindow = new SettingsWindow();
             settingsWindow.Owner = this;
             settingsWindow.Closing += SettingsWindow_Closing;
@@ -605,6 +608,8 @@ namespace ArcGIS.Samples.Desktop
         {
             SetScreenshotButttonVisibility();
             SetContainerDimensions();
+
+            _settingsWindowOpen = false;
 
             // Reactivate the parent window so that it does not minimize on close.
             Activate();


### PR DESCRIPTION
# Description

Add a flag to prevent duplicate settings windows from being open at once in the WPF sample viewer app.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
