### PR TITLE
Display download data progress on mobile

### DIFF
--- a/src/MAUI/Maui.Samples/Views/WaitPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/WaitPage.xaml
@@ -5,9 +5,7 @@
         <Border BackgroundColor="Transparent"
                 HorizontalOptions="Center"
                 StrokeThickness="0"
-                VerticalOptions="Center"
-                WidthRequest="{OnIdiom Phone=-1,
-                                       Desktop=500}">
+                VerticalOptions="Center">
             <Grid Padding="10" RowDefinitions="auto,auto,auto">
                 <Label x:Name="DownloadLabel"
                        Grid.Row="0"


### PR DESCRIPTION
# Description

Fixes a bug which prevented the download data bar from being visible on mobile.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
