### PR TITLE
Adds the required iOS privacy manifest

### DIFF
--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -177,5 +177,9 @@
     </MauiFont>
   </ItemGroup>
 
+  <!-- Apple Privacy Manifest file, more information: https://aka.ms/maui-privacy-manifest -->
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <Import Project="..\..\Samples.Shared\ArcGIS.Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/MAUI/Maui.Samples/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/src/MAUI/Maui.Samples/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -17,7 +17,7 @@ More information: https://aka.ms/maui-privacy-manifest
             <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
             <array>
-				<string>3B52.1</string>
+                <string>3B52.1</string>
                 <string>C617.1</string>
             </array>
         </dict>

--- a/src/MAUI/Maui.Samples/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/src/MAUI/Maui.Samples/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,51 @@
+<!--
+This is the minimum required version of the Apple Privacy Manifest for .NET MAUI apps and using the ArcGIS Maps SDK.
+The contents below are needed because of APIs that are used in the .NET framework and .NET MAUI SDK.
+
+You are responsible for adding extra entries as needed for your application.
+
+More information: https://aka.ms/maui-privacy-manifest
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+				<string>3B52.1</string>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <!-- The entry below is only needed when you're using the Preferences API in your app. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
# Description

Required manifest needed for submitting iOS apps to the store - includes .NET + ArcGIS Maps SDK manifest settings needed.
See https://devblogs.microsoft.com/dotnet/apple-privacy-manifest-support/

## Type of change

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
