### PR TITLE
`GeodatabaseTransactions` fixes

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -15,6 +15,7 @@ using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI.Editing;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
+using System.Linq.Expressions;
 
 namespace ArcGIS.Samples.GeodatabaseTransactions
 {
@@ -58,11 +59,19 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             // When the map view loads, add the local geodatabase tables as feature layers.
             MyMapView.Loaded += async (s, e) =>
             {
-                // Call a function (and await it) to get the local geodatabase (or generate it from the feature service).
-                await GetLocalGeodatabase();
+                try
+                {
+                    // Call a function (and await it) to get the local geodatabase (or generate it from the feature service).
+                    await GetLocalGeodatabase();
 
-                // Once the local geodatabase is available, load the tables as layers to the map.
-                await LoadLocalGeodatabaseTables();
+                    // Once the local geodatabase is available, load the tables as layers to the map.
+                    await LoadLocalGeodatabaseTables();
+                }
+                catch (Exception ex)
+                {
+                    // Show the exception message.
+                    MessageTextBlock.Text = ex.Message;
+                }
 
                 // Create a graphic for the geodatabase extent.
                 var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 2);
@@ -321,7 +330,9 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
 
         private async void StopEditTransaction(object sender, EventArgs e)
         {
-            // Ensure the geometry editor is stopped since user is leaving editing mode.
+            // Ensure the geometry editor is stopped and property changed event is unsubscribed since user is leaving editing mode.
+            // Handles case where user stops transaction while geometry editor is active.
+            MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
             MyMapView.GeometryEditor.Stop();
 
             // Handle the case where there are no edits to commit or rollback.

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         private const string SyncServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer/";
 
         // Work in a small extent south of Galveston, TX.
-        private Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
+        private readonly Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
 
         // Store the local geodatabase to edit.
         private Geodatabase _localGeodatabase;
@@ -72,25 +72,31 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                     // Show the exception message.
                     MessageTextBlock.Text = ex.Message;
                 }
-
-                // Create a graphic for the geodatabase extent.
-                var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 2);
-                var extentGraphic = new Graphic(_extent, lineSymbol);
-
-                // Create a graphics overlay for the extent graphic and apply a renderer.
-                var extentOverlay = new GraphicsOverlay
-                {
-                    Graphics = { extentGraphic },
-                    Renderer = new SimpleRenderer(lineSymbol)
-                };
-
-                // Add graphics overlay to the map view.
-                MyMapView.GraphicsOverlays.Add(extentOverlay);
             };
 
             // Create a new map with the oceans basemap and add it to the map view.
             var map = new Map(BasemapStyle.ArcGISOceans);
             MyMapView.Map = map;
+
+            // Create a graphic for the extent of the geodatabase and add it to the map view.
+            ShowExtent();
+        }
+
+        private void ShowExtent()
+        {
+            // Create a graphic for the geodatabase extent.
+            var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 2);
+            var extentGraphic = new Graphic(_extent, lineSymbol);
+
+            // Create a graphics overlay for the extent graphic and apply a renderer.
+            var extentOverlay = new GraphicsOverlay
+            {
+                Graphics = { extentGraphic },
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
+
+            // Add graphics overlay to the map view.
+            MyMapView.GraphicsOverlays.Add(extentOverlay);
         }
 
         private async Task GetLocalGeodatabase()

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -12,8 +12,9 @@ using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
-using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Editing;
+using Esri.ArcGISRuntime.Symbology;
+using Esri.ArcGISRuntime.UI;
 
 namespace ArcGIS.Samples.GeodatabaseTransactions
 {
@@ -41,22 +42,45 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         // Store a reference to the table to be edited.
         private GeodatabaseFeatureTable _editTable;
 
+        // Flag indicating if an edit exists which is not committed and was created during a transaction.
+        // Not to be confused with HasLocalEdits() which is for local edits not synchronized with the service.
+        private bool _hasUncommittedEdits;
+
         public GeodatabaseTransactions()
         {
             InitializeComponent();
 
-            // When the spatial reference changes (the map loads) add the local geodatabase tables as feature layers.
-            MyMapView.SpatialReferenceChanged += async (s, e) =>
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            // When the map view loads, add the local geodatabase tables as feature layers.
+            MyMapView.Loaded += async (s, e) =>
             {
                 // Call a function (and await it) to get the local geodatabase (or generate it from the feature service).
                 await GetLocalGeodatabase();
 
                 // Once the local geodatabase is available, load the tables as layers to the map.
                 await LoadLocalGeodatabaseTables();
+
+                // Create a graphic for the geodatabase extent.
+                var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 2);
+                var extentGraphic = new Graphic(_extent, lineSymbol);
+
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                var extentOverlay = new GraphicsOverlay
+                {
+                    Graphics = { extentGraphic },
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
             };
 
             // Create a new map with the oceans basemap and add it to the map view.
-            Map map = new Map(BasemapStyle.ArcGISOceans);
+            var map = new Map(BasemapStyle.ArcGISOceans);
             MyMapView.Map = map;
         }
 
@@ -73,12 +97,12 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                     // If the geodatabase is already available, open it, hide the progress control, and update the message.
                     _localGeodatabase = await Geodatabase.OpenAsync(localGeodatabasePath);
                     LoadingProgressBar.IsVisible = false;
-                    MessageTextBlock.Text = "Using local geodatabase from '" + _localGeodatabase.Path + "'";
+                    MessageTextBlock.Text = "Using local geodatabase from '" + _localGeodatabase.Path + "'.";
                 }
                 else
                 {
                     // Create a new GeodatabaseSyncTask with the uri of the feature server to pull from.
-                    Uri uri = new Uri(SyncServiceUrl);
+                    var uri = new Uri(SyncServiceUrl);
                     GeodatabaseSyncTask gdbTask = await GeodatabaseSyncTask.CreateAsync(uri);
 
                     // Create parameters for the task: layers and extent to include, out spatial reference, and sync model.
@@ -102,7 +126,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                             {
                                 // Hide the progress control and update the message.
                                 LoadingProgressBar.IsVisible = false;
-                                MessageTextBlock.Text = "Created local geodatabase";
+                                MessageTextBlock.Text = "Created local geodatabase.";
                             });
                         }
                         else if (generateGdbJob.Status == JobStatus.Failed)
@@ -123,10 +147,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             catch (Exception ex)
             {
                 // Show a message for the exception encountered.
-                Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
-                {
-                    Application.Current.MainPage.DisplayAlert("Generate Geodatabase", "Unable to create offline database: " + ex.Message, "OK");
-                });
+                MessageTextBlock.Text = ex.Message;
             }
         }
 
@@ -156,12 +177,13 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                     }
 
                     // Create a new feature layer to show the table in the map.
-                    FeatureLayer layer = new FeatureLayer(table);
+                    var layer = new FeatureLayer(table);
                     Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() => MyMapView.Map?.OperationalLayers.Add(layer));
                 }
                 catch (Exception e)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                    // Report the exception.
+                    MessageTextBlock.Text = e.Message;
                 }
             }
 
@@ -191,6 +213,9 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                 StartEditingButton.IsEnabled = !e.IsInTransaction;
                 SyncEditsButton.IsEnabled = !e.IsInTransaction;
                 RequireTransactionCheckBox.IsEnabled = !e.IsInTransaction;
+
+                // Always flag when starting or leaving an editing session.
+                _hasUncommittedEdits = false;
             });
         }
 
@@ -214,7 +239,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             {
                 // If not, begin a transaction.
                 _localGeodatabase.BeginTransaction();
-                MessageTextBlock.Text = "Transaction started";
+                MessageTextBlock.Text = "Transaction started.";
             }
         }
 
@@ -236,12 +261,16 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                 }
 
                 // Inform the user which table is being edited.
-                MessageTextBlock.Text = "Click the map to add a new feature to the geodatabase table '" + _editTable.TableName + "'";
+                MessageTextBlock.Text = "Click the map to add a new feature to the geodatabase table '" + _editTable.TableName + "'.";
 
                 // Use the geometry editor to allow the user to draw a point on the map.
-                MyMapView.GeometryEditor.Start(GeometryType.Point);
-
-                MyMapView.GeometryEditor.PropertyChanged += GeometryEditor_PropertyChanged;
+                if (!MyMapView.GeometryEditor.IsStarted)
+                {
+                    MyMapView.GeometryEditor.Start(GeometryType.Point);
+                    
+                    MyMapView.GeometryEditor.PropertyChanged += GeometryEditor_PropertyChanged;
+                }
+                
             }
             catch (Exception ex)
             {
@@ -253,38 +282,59 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         private async void GeometryEditor_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             // Check if the user finished drawing a point on the map.
-            if (e.PropertyName == nameof(GeometryEditor.Geometry))
+            if (e.PropertyName == nameof(GeometryEditor.Geometry) && MyMapView.GeometryEditor.Geometry?.IsEmpty == false )
             {
                 // Disconnect event handler to prevent multiple calls.
                 MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
 
                 // Get the active geometry.
-                Geometry geometry = MyMapView.GeometryEditor.Geometry;
+                Geometry geometry = MyMapView.GeometryEditor.Stop();
 
                 // Create a new feature (row) in the selected table.
                 Feature newFeature = _editTable.CreateFeature();
 
                 // Create a random value for the 'type' attribute (integer between 1 and 7).
-                Random random = new Random(DateTime.Now.Millisecond);
+                var random = new Random(DateTime.Now.Millisecond);
                 int featureType = random.Next(1, 7);
 
                 // Set the geometry with the point the user clicked and the 'type' with the random integer.
                 newFeature.Geometry = geometry;
                 newFeature.SetAttributeValue("type", featureType);
 
-                // Add the new feature to the table.
-                await _editTable.AddFeatureAsync(newFeature);
+                try
+                {
+                    // Add the new feature to the table.
+                    await _editTable.AddFeatureAsync(newFeature);
 
-                // Set the newly created feature message.
-                MessageTextBlock.Text = "New feature added to the '" + _editTable.TableName + "' table";
+                    // Set the newly created feature message.
+                    MessageTextBlock.Text = "New feature added to the '" + _editTable.TableName + "' table";
 
-                // Stop the geometry editor, clearing the active geometry.
-                MyMapView.GeometryEditor.Stop();
+                    _hasUncommittedEdits = true;
+                }
+                catch (Exception ex)
+                {
+                    // Report the exception message.
+                    MessageTextBlock.Text = ex.Message;
+                }
             }
         }
 
         private async void StopEditTransaction(object sender, EventArgs e)
         {
+            // Ensure the geometry editor is stopped since user is leaving editing mode.
+            MyMapView.GeometryEditor.Stop();
+
+            // Handle the case where there are no edits to commit or rollback.
+            if (!_hasUncommittedEdits)
+            {
+                MessageTextBlock.Text = "No edits to commit or rollback.";
+
+                // Raise the transaction status changed event to update the UI and reset the flag.
+                _localGeodatabase.RollbackTransaction();
+
+                return;
+            }
+
             try
             {
                 // Ask the user if they want to commit or rollback the transaction (or cancel to keep working in the transaction).
@@ -292,27 +342,20 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
 
                 if (choice == "Commit")
                 {
-                    // See if there is a transaction active for the geodatabase.
-                    if (_localGeodatabase.IsInTransaction)
-                    {
-                        // If there is, commit the transaction to store the edits (this will also end the transaction).
-                        _localGeodatabase.CommitTransaction();
-                        MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
-                    }
+                    // Commit the transaction to store the edits (this will also end the transaction).
+                    _localGeodatabase.CommitTransaction();
+                    MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
                 }
-                else if (choice == "Rollback")
+                else if (choice == "Rollback") // TODO: remove nested if on other implementations
                 {
-                    // See if there is a transaction active for the geodatabase.
-                    if (_localGeodatabase.IsInTransaction)
-                    {
-                        // If there is, rollback the transaction to discard the edits (this will also end the transaction).
-                        _localGeodatabase.RollbackTransaction();
-                        MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
-                    }
+                    // Rollback the transaction to discard the edits (this will also end the transaction).
+                    _localGeodatabase.RollbackTransaction();
+                    MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
                 }
                 else
                 {
-                    // For 'cancel' don't end the transaction with a commit or rollback.
+                    // User canceled.
+                    MessageTextBlock.Text = "Transaction still going.";
                 }
             }
             catch (Exception ex)
@@ -348,6 +391,13 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         // Synchronize edits in the local geodatabase with the service.
         public async void SynchronizeEdits(object sender, EventArgs e)
         {
+            // Don't attempt to sync if there are no local edits.
+            if (!_localGeodatabase.HasLocalEdits())
+            {
+                MessageTextBlock.Text = "No local edits to synchronize.";
+                return;
+            }
+
             // Show the progress bar while the sync is working.
             LoadingProgressBar.IsVisible = true;
 

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         private void Initialize()
         {
             // When the map view loads, add the local geodatabase tables as feature layers.
-            MyMapView.Loaded += async (s, e) =>
+            MyMapView.SpatialReferenceChanged += async (s, e) =>
             {
                 try
                 {

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -362,7 +362,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                     _localGeodatabase.CommitTransaction();
                     MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
                 }
-                else if (choice == "Rollback") // TODO: remove nested if on other implementations
+                else if (choice == "Rollback")
                 {
                     // Rollback the transaction to discard the edits (this will also end the transaction).
                     _localGeodatabase.RollbackTransaction();

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -276,10 +276,9 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
                 if (!MyMapView.GeometryEditor.IsStarted)
                 {
                     MyMapView.GeometryEditor.Start(GeometryType.Point);
-                    
+
                     MyMapView.GeometryEditor.PropertyChanged += GeometryEditor_PropertyChanged;
                 }
-                
             }
             catch (Exception ex)
             {
@@ -291,7 +290,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
         private async void GeometryEditor_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             // Check if the user finished drawing a point on the map.
-            if (e.PropertyName == nameof(GeometryEditor.Geometry) && MyMapView.GeometryEditor.Geometry?.IsEmpty == false )
+            if (e.PropertyName == nameof(GeometryEditor.Geometry) && MyMapView.GeometryEditor.Geometry?.IsEmpty == false)
             {
                 // Disconnect event handler to prevent multiple calls.
                 MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;

--- a/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -36,7 +36,7 @@ namespace ArcGIS.WPF.Samples.GeodatabaseTransactions
         private const string SyncServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer/";
 
         // Work in a small extent south of Galveston, TX.
-        private Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
+        private readonly Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
 
         // Store the local geodatabase to edit.
         private Geodatabase _localGeodatabase;
@@ -76,21 +76,27 @@ namespace ArcGIS.WPF.Samples.GeodatabaseTransactions
 
                 // Once the local geodatabase is available, load the tables as layers to the map.
                 _ = LoadLocalGeodatabaseTables();
-
-                // Create a graphic for the geodatabase extent.
-                var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-                var extentGraphic = new Graphic(_extent, lineSymbol);
-
-                // Create a graphics overlay for the extent graphic and apply a renderer.
-                var extentOverlay = new GraphicsOverlay
-                {
-                    Graphics = { extentGraphic },
-                    Renderer = new SimpleRenderer(lineSymbol)
-                };
-
-                // Add graphics overlay to the map view.
-                MyMapView.GraphicsOverlays.Add(extentOverlay);
             };
+
+            // Create a graphic for the extent of the geodatabase and add it to the map view.
+            ShowExtent();
+        }
+
+        private void ShowExtent()
+        {
+            // Create a graphic for the geodatabase extent.
+            var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+            var extentGraphic = new Graphic(_extent, lineSymbol);
+
+            // Create a graphics overlay for the extent graphic and apply a renderer.
+            var extentOverlay = new GraphicsOverlay
+            {
+                Graphics = { extentGraphic },
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
+
+            // Add graphics overlay to the map view.
+            MyMapView.GraphicsOverlays.Add(extentOverlay);
         }
 
         private async Task GetLocalGeodatabase()

--- a/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -315,7 +315,9 @@ namespace ArcGIS.WPF.Samples.GeodatabaseTransactions
 
         private void StopEditTransaction(object sender, RoutedEventArgs e)
         {
-            // Ensure the geometry editor is stopped since user is leaving editing mode.
+            // Ensure the geometry editor is stopped and property changed event is unsubscribed since user is leaving editing mode.
+            // Handles case where user stops transaction while geometry editor is active.
+            MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
             MyMapView.GeometryEditor.Stop();
 
             // Handle the case where there are no edits to commit or rollback.
@@ -334,23 +336,15 @@ namespace ArcGIS.WPF.Samples.GeodatabaseTransactions
 
             if (commitAnswer == MessageBoxResult.Yes)
             {
-                // See if there is a transaction active for the geodatabase.
-                if (_localGeodatabase.IsInTransaction)
-                {
-                    // Commit the transaction to store the edits (this will also end the transaction).
-                    _localGeodatabase.CommitTransaction();
-                    MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
-                }
+                // Commit the transaction to store the edits (this will also end the transaction).
+                _localGeodatabase.CommitTransaction();
+                MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
             }
             else if (commitAnswer == MessageBoxResult.No)
             {
-                // See if there is a transaction active for the geodatabase.
-                if (_localGeodatabase.IsInTransaction)
-                {
-                    // Rollback the transaction to discard the edits (this will also end the transaction).
-                    _localGeodatabase.RollbackTransaction();
-                    MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
-                }
+                // Rollback the transaction to discard the edits (this will also end the transaction).
+                _localGeodatabase.RollbackTransaction();
+                MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
             }
             else
             {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -167,7 +167,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         {
             if (_localGeodatabase == null) { return; }
 
-            // Read the geodatabase tables and add them as layers
+            // Read the geodatabase tables and add them as layers.
             foreach (GeodatabaseFeatureTable table in _localGeodatabase.GeodatabaseFeatureTables)
             {
                 try
@@ -320,7 +320,9 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
 
         private async void StopEditTransaction(object sender, RoutedEventArgs e)
         {
-            // Ensure the geometry editor is stopped since user is leaving editing mode.
+            // Ensure the geometry editor is stopped and property changed event is unsubscribed since user is leaving editing mode.
+            // Handles case where user stops transaction while geometry editor is active.
+            MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
             MyMapView.GeometryEditor.Stop();
 
             // Handle the case where there are no edits to commit or rollback.
@@ -351,23 +353,15 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
 
                 if (cmd.Label == commitCommand.Label)
                 {
-                    // See if there is a transaction active for the geodatabase.
-                    if (_localGeodatabase.IsInTransaction)
-                    {
-                        // Commit the transaction to store the edits (this will also end the transaction).
-                        _localGeodatabase.CommitTransaction();
-                        MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
-                    }
+                    // Commit the transaction to store the edits (this will also end the transaction).
+                    _localGeodatabase.CommitTransaction();
+                    MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
                 }
                 else if (cmd.Label == rollbackCommand.Label)
                 {
-                    // See if there is a transaction active for the geodatabase.
-                    if (_localGeodatabase.IsInTransaction)
-                    {
-                        // Rollback the transaction to discard the edits (this will also end the transaction).
-                        _localGeodatabase.RollbackTransaction();
-                        MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
-                    }
+                    // Rollback the transaction to discard the edits (this will also end the transaction).
+                    _localGeodatabase.RollbackTransaction();
+                    MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
                 }
                 else
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -50,10 +50,6 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         // Store a reference to the table to be edited.
         private GeodatabaseFeatureTable _editTable;
 
-        // Flag indicating if an edit exists which is not committed and was created during a transaction.
-        // Not to be confused with HasLocalEdits() which is for local edits not synchronized with the service.
-        private bool _hasUncommittedEdits;
-
         public GeodatabaseTransactions()
         {
             InitializeComponent();
@@ -227,9 +223,6 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 // These buttons should be enabled when there is NOT a transaction.
                 StartEditingButton.IsEnabled = !e.IsInTransaction;
                 SyncEditsButton.IsEnabled = !e.IsInTransaction;
-
-                // Always flag when starting or leaving an editing session.
-                _hasUncommittedEdits = false;
             });
         }
 
@@ -314,7 +307,6 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 {
                     await _editTable.AddFeatureAsync(newFeature);
                     MessageTextBlock.Text = "New feature added to the '" + _editTable.TableName + "' table.";
-                    _hasUncommittedEdits = true;
                 }
                 catch (ArcGISException ex)
                 {
@@ -330,17 +322,6 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
             // Handles case where user stops transaction while geometry editor is active.
             MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
             MyMapView.GeometryEditor.Stop();
-
-            // Handle the case where there are no edits to commit or rollback.
-            if (!_hasUncommittedEdits)
-            {
-                MessageTextBlock.Text = "No edits to commit or rollback.";
-
-                // Raise the transaction status changed event to update the UI and reset the flag.
-                _localGeodatabase.RollbackTransaction();
-
-                return;
-            }
 
             // Create a new dialog that prompts for commit, rollback, or cancel
             var promptDialog = new MessageDialog2("Commit your edits to the local geodatabase or rollback to discard them.", "Stop Editing");
@@ -361,13 +342,15 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 {
                     // Commit the transaction to store the edits (this will also end the transaction).
                     _localGeodatabase.CommitTransaction();
-                    MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
+                    MessageTextBlock.Text = _localGeodatabase.HasLocalEdits() ?
+                        "Edits were committed to the local geodatabase." : "No edits committed.";
                 }
                 else if (cmd.Label == rollbackCommand.Label)
                 {
                     // Rollback the transaction to discard the edits (this will also end the transaction).
                     _localGeodatabase.RollbackTransaction();
-                    MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
+                    MessageTextBlock.Text = _localGeodatabase.HasLocalEdits() ?
+                        "Edits were rolled back and not stored to the local geodatabase." : "No edits were rolled back.";
                 }
                 else
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -38,7 +38,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         private const string SyncServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer/";
 
         // Work in a small extent south of Galveston, TX.
-        private Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
+        private readonly Envelope _extent = new Envelope(-95.3035, 29.0100, -95.1053, 29.1298, SpatialReferences.Wgs84);
 
         // Store the local geodatabase to edit.
         private Geodatabase _localGeodatabase;
@@ -78,21 +78,27 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
 
                 // Once the local geodatabase is available, load the tables as layers to the map.
                 _ = LoadLocalGeodatabaseTables();
-
-                // Create a graphic for the geodatabase extent.
-                var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-                var extentGraphic = new Graphic(_extent, lineSymbol);
-
-                // Create a graphics overlay for the extent graphic and apply a renderer.
-                var extentOverlay = new GraphicsOverlay
-                {
-                    Graphics = { extentGraphic },
-                    Renderer = new SimpleRenderer(lineSymbol)
-                };
-
-                // Add graphics overlay to the map view.
-                MyMapView.GraphicsOverlays.Add(extentOverlay);
             };
+
+            // Create a graphic for the extent of the geodatabase and add it to the map view.
+            ShowExtent();
+        }
+
+        private void ShowExtent()
+        {
+            // Create a graphic for the geodatabase extent.
+            var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+            var extentGraphic = new Graphic(_extent, lineSymbol);
+
+            // Create a graphics overlay for the extent graphic and apply a renderer.
+            var extentOverlay = new GraphicsOverlay
+            {
+                Graphics = { extentGraphic },
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
+
+            // Add graphics overlay to the map view.
+            MyMapView.GraphicsOverlays.Add(extentOverlay);
         }
 
         private async Task GetLocalGeodatabase()

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -7,15 +7,19 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // Language governing permissions and limitations under the License.
 
+using Esri.ArcGISRuntime;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Editing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.UI.Popups;
@@ -46,16 +50,24 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         // Store a reference to the table to be edited.
         private GeodatabaseFeatureTable _editTable;
 
+        // Flag indicating if an edit exists which is not committed and was created during a transaction.
+        // Not to be confused with HasLocalEdits() which is for local edits not synchronized with the service.
+        private bool _hasUncommittedEdits;
+
         public GeodatabaseTransactions()
         {
             InitializeComponent();
 
+            Initialize();
+        }
+
+        private void Initialize()
+        {
             // When the map view loads, add a new map.
             MyMapView.Loaded += (s, e) =>
             {
                 // Create a new map with the oceans basemap and add it to the map view.
-                Map map = new Map(BasemapStyle.ArcGISOceans);
-                MyMapView.Map = map;
+                MyMapView.Map = new Map(BasemapStyle.ArcGISOceans);
             };
 
             // When the spatial reference changes (the map loads) add the local geodatabase tables as feature layers.
@@ -65,7 +77,21 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 await GetLocalGeodatabase();
 
                 // Once the local geodatabase is available, load the tables as layers to the map.
-                await LoadLocalGeodatabaseTables();
+                _ = LoadLocalGeodatabaseTables();
+
+                // Create a graphic for the geodatabase extent.
+                var lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+                var extentGraphic = new Graphic(_extent, lineSymbol);
+
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                var extentOverlay = new GraphicsOverlay
+                {
+                    Graphics = { extentGraphic },
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
             };
         }
 
@@ -82,12 +108,12 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                     // If the geodatabase is already available, open it, hide the progress control, and update the message.
                     _localGeodatabase = await Geodatabase.OpenAsync(localGeodatabasePath);
                     LoadingProgressBar.Visibility = Visibility.Collapsed;
-                    MessageTextBlock.Text = "Using local geodatabase from '" + _localGeodatabase.Path + "'";
+                    MessageTextBlock.Text = "Using local geodatabase from '" + _localGeodatabase.Path + "'.";
                 }
                 else
                 {
                     // Create a new GeodatabaseSyncTask with the uri of the feature server to pull from.
-                    Uri uri = new Uri(SyncServiceUrl);
+                    var uri = new Uri(SyncServiceUrl);
                     GeodatabaseSyncTask gdbTask = await GeodatabaseSyncTask.CreateAsync(uri);
 
                     // Create parameters for the task: layers and extent to include, out spatial reference, and sync model.
@@ -111,7 +137,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                             {
                                 // Hide the progress control and update the message.
                                 LoadingProgressBar.Visibility = Visibility.Collapsed;
-                                MessageTextBlock.Text = "Created local geodatabase";
+                                MessageTextBlock.Text = "Created local geodatabase.";
                             });
                         }
                         else if (generateGdbJob.Status == JobStatus.Failed)
@@ -132,10 +158,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
             catch (Exception ex)
             {
                 // Show a message for the exception encountered.
-                DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
-                {
-                    _ = new MessageDialog2("Unable to create offline database: " + ex.Message).ShowAsync();
-                });
+                MessageTextBlock.Text = ex.Message;
             }
         }
 
@@ -144,7 +167,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         {
             if (_localGeodatabase == null) { return; }
 
-            // Read the geodatabase tables and add them as layers.
+            // Read the geodatabase tables and add them as layers
             foreach (GeodatabaseFeatureTable table in _localGeodatabase.GeodatabaseFeatureTables)
             {
                 try
@@ -165,12 +188,12 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                     }
 
                     // Create a new feature layer to show the table in the map.
-                    FeatureLayer layer = new FeatureLayer(table);
+                    var layer = new FeatureLayer(table);
                     DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () => MyMapView.Map?.OperationalLayers.Add(layer));
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    await new MessageDialog2(e.ToString(), "Error").ShowAsync();
+                    MessageTextBlock.Text = ex.Message;
                 }
             }
 
@@ -198,6 +221,9 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 // These buttons should be enabled when there is NOT a transaction.
                 StartEditingButton.IsEnabled = !e.IsInTransaction;
                 SyncEditsButton.IsEnabled = !e.IsInTransaction;
+
+                // Always flag when starting or leaving an editing session.
+                _hasUncommittedEdits = false;
             });
         }
 
@@ -215,7 +241,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
             {
                 // If not, begin a transaction.
                 _localGeodatabase.BeginTransaction();
-                MessageTextBlock.Text = "Transaction started";
+                MessageTextBlock.Text = "Transaction started.";
             }
         }
 
@@ -237,12 +263,15 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 }
 
                 // Inform the user which table is being edited.
-                MessageTextBlock.Text = "Click the map to add a new feature to the geodatabase table '" + _editTable.TableName + "'";
+                MessageTextBlock.Text = "Click the map to add a new feature to the geodatabase table '" + _editTable.TableName + "'.";
 
-                // Use the geometry editor to allow the user to draw a point on the map.
-                MyMapView.GeometryEditor.Start(GeometryType.Point);
+                if (!MyMapView.GeometryEditor.IsStarted)
+                {
+                    // Use the geometry editor to allow the user to draw a point on the map.
+                    MyMapView.GeometryEditor.Start(GeometryType.Point);
 
-                MyMapView.GeometryEditor.PropertyChanged += GeometryEditor_PropertyChanged;
+                    MyMapView.GeometryEditor.PropertyChanged += GeometryEditor_PropertyChanged;
+                }
             }
             catch (Exception ex)
             {
@@ -254,19 +283,19 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         private async void GeometryEditor_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             // Check if the user finished drawing a point on the map.
-            if (e.PropertyName == nameof(GeometryEditor.Geometry))
+            if (e.PropertyName == nameof(GeometryEditor.Geometry) && MyMapView.GeometryEditor.Geometry?.IsEmpty == false)
             {
                 // Disconnect event handler to prevent multiple calls.
                 MyMapView.GeometryEditor.PropertyChanged -= GeometryEditor_PropertyChanged;
 
                 // Get the active geometry.
-                Geometry geometry = MyMapView.GeometryEditor.Geometry;
+                Geometry geometry = MyMapView.GeometryEditor.Stop();
 
                 // Create a new feature (row) in the selected table.
                 Feature newFeature = _editTable.CreateFeature();
 
                 // Create a random value for the 'type' attribute (integer between 1 and 7).
-                Random random = new Random(DateTime.Now.Millisecond);
+                var random = new Random(DateTime.Now.Millisecond);
                 int featureType = random.Next(1, 7);
 
                 // Set the geometry with the point the user clicked and the 'type' with the random integer.
@@ -274,23 +303,42 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                 newFeature.SetAttributeValue("type", featureType);
 
                 // Add the new feature to the table.
-                await _editTable.AddFeatureAsync(newFeature);
-
-                // Set the newly created feature message.
-                MessageTextBlock.Text = "New feature added to the '" + _editTable.TableName + "' table";
-
-                // Stop the geometry editor, clearing the active geometry.
-                MyMapView.GeometryEditor.Stop();
+                string message = string.Empty;
+                try
+                {
+                    await _editTable.AddFeatureAsync(newFeature);
+                    MessageTextBlock.Text = "New feature added to the '" + _editTable.TableName + "' table.";
+                    _hasUncommittedEdits = true;
+                }
+                catch (ArcGISException ex)
+                {
+                    // Report the exception message.
+                    MessageTextBlock.Text = ex.Message;
+                }
             }
         }
 
         private async void StopEditTransaction(object sender, RoutedEventArgs e)
         {
+            // Ensure the geometry editor is stopped since user is leaving editing mode.
+            MyMapView.GeometryEditor.Stop();
+
+            // Handle the case where there are no edits to commit or rollback.
+            if (!_hasUncommittedEdits)
+            {
+                MessageTextBlock.Text = "No edits to commit or rollback.";
+
+                // Raise the transaction status changed event to update the UI and reset the flag.
+                _localGeodatabase.RollbackTransaction();
+
+                return;
+            }
+
             // Create a new dialog that prompts for commit, rollback, or cancel
             var promptDialog = new MessageDialog2("Commit your edits to the local geodatabase or rollback to discard them.", "Stop Editing");
-            UICommand commitCommand = new UICommand("Commit");
-            UICommand rollbackCommand = new UICommand("Rollback");
-            UICommand cancelCommand = new UICommand("Cancel");
+            var commitCommand = new UICommand("Commit");
+            var rollbackCommand = new UICommand("Rollback");
+            var cancelCommand = new UICommand("Cancel");
             promptDialog.Options = MessageDialogOptions.None;
             promptDialog.Commands.Add(commitCommand);
             promptDialog.Commands.Add(rollbackCommand);
@@ -306,7 +354,7 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                     // See if there is a transaction active for the geodatabase.
                     if (_localGeodatabase.IsInTransaction)
                     {
-                        // If there is, commit the transaction to store the edits (this will also end the transaction).
+                        // Commit the transaction to store the edits (this will also end the transaction).
                         _localGeodatabase.CommitTransaction();
                         MessageTextBlock.Text = "Edits were committed to the local geodatabase.";
                     }
@@ -316,18 +364,21 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
                     // See if there is a transaction active for the geodatabase.
                     if (_localGeodatabase.IsInTransaction)
                     {
-                        // If there is, rollback the transaction to discard the edits (this will also end the transaction).
+                        // Rollback the transaction to discard the edits (this will also end the transaction).
                         _localGeodatabase.RollbackTransaction();
                         MessageTextBlock.Text = "Edits were rolled back and not stored to the local geodatabase.";
                     }
                 }
                 else
                 {
-                    // For 'cancel' don't end the transaction with a commit or rollback.
+                    // User canceled.
+                    MessageTextBlock.Text = "Transaction still going.";
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                // Report the exception message.
+                MessageTextBlock.Text = ex.Message;
             }
         }
 
@@ -358,6 +409,13 @@ namespace ArcGIS.WinUI.Samples.GeodatabaseTransactions
         // Synchronize edits in the local geodatabase with the service.
         public async void SynchronizeEdits(object sender, RoutedEventArgs e)
         {
+            // Don't attempt to sync if there are no local edits.
+            if (!_localGeodatabase.HasLocalEdits())
+            {
+                MessageTextBlock.Text = "No local edits to synchronize.";
+                return;
+            }
+
             // Show the progress bar while the sync is working.
             LoadingProgressBar.Visibility = Visibility.Visible;
 


### PR DESCRIPTION
# Description

Fixes:
* Handles exception when adding geometry outside of geodatabase extent.
* Ensures geometry editor is stopped and property changed event is unsubscribed.
* Checks for local edits before attempting to sync.

Code style:
* Follows established `Initialize()` pattern.
* Uses `var` during object instantiation.
* Limits `GeometryEditor.PropertyChanged` event subscriptions.

UIX:
* Symbolizes geodatabase extent with red rectangle.
* Reports exceptions to the control panel.
* Handles case when there are no edits to commit.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
