### PR TITLE
.NET MAUI: use 8.0.20 package version

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,8 +31,8 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.6" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.20" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates the package versions from 8.0.6 -> 8.0.20

https://github.com/dotnet/maui/releases/tag/8.0.20