### PR TITLE
`DisplayClusters` attribute table and readme

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml
@@ -27,12 +27,10 @@
                              Padding="5"
                              Spacing="5">
                     <esriTK:PopupViewer x:Name="PopupViewer"
-                                        MaximumHeightRequest="{OnIdiom Default=150,
-                                                                       Phone=150}"
                                         MaximumWidthRequest="{OnIdiom Default=750,
                                                                       Phone=250}"
-                                        MinimumHeightRequest="{OnIdiom Phone=150}"
-                                        MinimumWidthRequest="{OnIdiom Phone=250}" />
+                                        MinimumWidthRequest="250"
+                                        HeightRequest="150" />
                     <StackLayout x:Name="GeoElementsPanel"
                                  Margin="5"
                                  Padding="5"

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml
@@ -23,11 +23,75 @@
                                                  Dark=#303030}"
                     HorizontalOptions="Center"
                     VerticalOptions="Center">
-                <esriTK:PopupViewer x:Name="PopupViewer"
-                                    Margin="5"
-                                    Padding="5"
-                                    HeightRequest="250"
-                                    WidthRequest="250" />
+                <StackLayout Margin="5"
+                             Padding="5"
+                             Spacing="5">
+                    <esriTK:PopupViewer x:Name="PopupViewer"
+                                        MaximumHeightRequest="{OnIdiom Default=150,
+                                                                       Phone=150}"
+                                        MaximumWidthRequest="{OnIdiom Default=750,
+                                                                      Phone=250}"
+                                        MinimumHeightRequest="{OnIdiom Phone=150}"
+                                        MinimumWidthRequest="{OnIdiom Phone=250}" />
+                    <StackLayout x:Name="GeoElementsPanel"
+                                 Margin="5"
+                                 Padding="5"
+                                 IsVisible="false"
+                                 Spacing="5">
+                        <Label FontAttributes="Bold" Text="Contained Geoelements:" />
+                        <!--  On phone, only show the name attribute.  -->
+                        <CollectionView x:Name="GeoElementsGrid"
+                                        MaximumHeightRequest="{OnIdiom Default=500,
+                                                                       Phone=250}"
+                                        MaximumWidthRequest="{OnIdiom Default=750,
+                                                                      Phone=250}">
+                            <CollectionView.Header>
+                                <Grid ColumnDefinitions="*,2*,*,*" ColumnSpacing="50">
+                                    <Label Grid.Column="0"
+                                           FontAttributes="Bold"
+                                           IsVisible="{OnIdiom Default=True,
+                                                               Phone=False}"
+                                           Text="Object ID" />
+                                    <Label Grid.Column="{OnIdiom Default=1,
+                                                                 Phone=0}"
+                                           Grid.ColumnSpan="{OnIdiom Default=0,
+                                                                     Phone=4}"
+                                           FontAttributes="Bold"
+                                           Text="Name" />
+                                    <Label Grid.Column="2"
+                                           FontAttributes="Bold"
+                                           IsVisible="{OnIdiom Default=True,
+                                                               Phone=False}"
+                                           Text="Capacity (MW)" />
+                                    <Label Grid.Column="3"
+                                           FontAttributes="Bold"
+                                           IsVisible="{OnIdiom Default=True,
+                                                               Phone=False}"
+                                           Text="Fuel" />
+                                </Grid>
+                            </CollectionView.Header>
+                            <CollectionView.ItemTemplate>
+                                <OnIdiom x:TypeArguments="DataTemplate">
+                                    <OnIdiom.Default>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,2*,*,*" ColumnSpacing="50">
+                                                <Label Text="{Binding Path=Attributes[objectid]}" />
+                                                <Label Grid.Column="1" Text="{Binding Path=Attributes[name]}" />
+                                                <Label Grid.Column="2" Text="{Binding Path=Attributes[capacity_mw]}" />
+                                                <Label Grid.Column="3" Text="{Binding Path=Attributes[fuel1]}" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </OnIdiom.Default>
+                                    <OnIdiom.Phone>
+                                        <DataTemplate>
+                                            <Label Text="{Binding Path=Attributes[name]}" />
+                                        </DataTemplate>
+                                    </OnIdiom.Phone>
+                                </OnIdiom>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </StackLayout>
+                </StackLayout>
             </Border>
         </Grid>
     </Grid>

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/readme.md
@@ -33,7 +33,6 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
-
 ## Additional information
 
 Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/readme.md
@@ -33,6 +33,11 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
+
+## Additional information
+
+Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.
+
 ## Tags
 
 aggregate, bin, cluster, group, merge, normalize, reduce, summarize

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml
@@ -5,24 +5,48 @@
     <Grid>
         <esri:MapView x:Name="MyMapView" GeoViewTapped="MyMapView_GeoViewTapped" />
         <Border Width="auto" Style="{StaticResource BorderStyle}">
-            <CheckBox Checked="CheckBox_CheckChanged"
-                      Content="Feature clustering"
-                      IsChecked="True"
-                      Unchecked="CheckBox_CheckChanged" />
+            <StackPanel>
+                <CheckBox Checked="EnableClusteringCheckBox_CheckChanged"
+                          Content="Feature clustering"
+                          IsChecked="True"
+                          Unchecked="EnableClusteringCheckBox_CheckChanged" />
+            </StackPanel>
         </Border>
         <Grid x:Name="PopupBackground"
               Background="#AA333333"
               MouseLeftButtonDown="PopupBackground_MouseLeftButtonDown"
               Visibility="Collapsed">
-            <Border HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Background="White">
+            <StackPanel MaxWidth="600"
+                        MaxHeight="500"
+                        Margin="5"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Background="White">
                 <esri:PopupViewer x:Name="PopupViewer"
-                                  MaxWidth="400"
-                                  MaxHeight="400"
-                                  Margin="5"
+                                  Margin="5,0,5,5"
                                   Padding="5" />
-            </Border>
+                <StackPanel x:Name="GeoElementsPanel"
+                            Margin="5,0,5,5"
+                            Visibility="Collapsed">
+                    <TextBlock Padding="10,0,10,5"
+                               FontWeight="Bold"
+                               Text="Contained Geoelements:" />
+                    <DataGrid x:Name="GeoElementsGrid"
+                              MaxHeight="250"
+                              Margin="10,5"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding Path=Attributes[objectid]}" Header="Object ID" />
+                            <DataGridTextColumn Binding="{Binding Path=Attributes[name]}" Header="Name" />
+                            <DataGridTextColumn Binding="{Binding Path=Attributes[capacity_mw]}" Header="Capacity (MW)" />
+                            <DataGridTextColumn Width="*"
+                                                Binding="{Binding Path=Attributes[fuel1]}"
+                                                Header="Fuel" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </StackPanel>
+            </StackPanel>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml.cs
@@ -9,8 +9,11 @@
 
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.Portal;
+using Esri.ArcGISRuntime.Reduction;
 using Esri.ArcGISRuntime.UI.Controls;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -22,11 +25,12 @@ namespace ArcGIS.WPF.Samples.DisplayClusters
         name: "Display clusters",
         category: "Layers",
         description: "Display a web map with a point feature layer that has feature reduction enabled to aggregate points into clusters.",
-        instructions: "Pan and zoom the map to view how clustering is dynamically updated. Toggle clustering off to view the original point features that make up the clustered elements. When clustering is on, you can click on a clustered geoelement to view aggregated information and summary statistics for that cluster. When clustering is toggled off and you click on the original feature you get access to information about individual power plant features.",
+        instructions: "Pan and zoom the map to view how clustering is dynamically updated. Toggle clustering off to view the original point features that make up the clustered elements. When clustering is on, you can click on a clustered geoelement to view aggregated information and summary statistics for that cluster as well as a list geo elements in the identified cluster. When clustering is toggled off and you click on the original feature you get access to information about individual power plant features.",
         tags: new[] { "aggregate", "bin", "cluster", "group", "merge", "normalize", "reduce", "summarize" })]
     [ArcGIS.Samples.Shared.Attributes.OfflineData()]
     public partial class DisplayClusters
     {
+        // Hold a reference to the feature layer.
         private FeatureLayer _layer;
 
         public DisplayClusters()
@@ -51,19 +55,44 @@ namespace ArcGIS.WPF.Samples.DisplayClusters
 
         private async void MyMapView_GeoViewTapped(object sender, GeoViewInputEventArgs e)
         {
+            // Clear any previously selected features or clusters.
+            _layer.ClearSelection();
+
             // Identify the tapped observation.
-            IdentifyLayerResult results = await MyMapView.IdentifyLayerAsync(_layer, e.Position, 3, true);
+            var results = await MyMapView.IdentifyLayerAsync(_layer, e.Position, 3, false);
 
             // Return if no popups are found.
-            if (results.Popups.Count == 0) return;
+            if (results.GeoElements.Count == 0 || results.Popups.Count == 0) return;
 
-            // Set the popup and make it visible.
-            PopupViewer.Popup = results.Popups.FirstOrDefault();
-            PopupBackground.Visibility = Visibility.Visible;
+            if (results.Popups.FirstOrDefault() is Popup popup)
+            {
+                // Set the popup and make it visible.
+                PopupViewer.Popup = popup;
+                PopupBackground.Visibility = Visibility.Visible;
+            }
+
+            // If the tapped observation is an AggregateGeoElement then select it.
+            if (results.GeoElements.FirstOrDefault() is AggregateGeoElement aggregateGeoElement)
+            {
+                // Select the AggregateGeoElement.
+                aggregateGeoElement.IsSelected = true;
+
+                // Get the contained GeoElements.
+                IReadOnlyList<GeoElement> geoElements = await aggregateGeoElement.GetGeoElementsAsync();
+
+                // Set the geoelements as an items source and set the visibility.
+                GeoElementsGrid.ItemsSource = geoElements;
+                GeoElementsPanel.Visibility = Visibility.Visible;
+            }
+            else if (results.GeoElements.FirstOrDefault() is ArcGISFeature feature)
+            {
+                // If the tapped observation is not an AggregateGeoElement select the feature.
+                _layer.SelectFeature(feature);
+            }
         }
 
         // Enable clustering feature reduction if the checkbox has been checked, disable otherwise.
-        private void CheckBox_CheckChanged(object sender, RoutedEventArgs e)
+        private void EnableClusteringCheckBox_CheckChanged(object sender, RoutedEventArgs e)
         {
             // This event is raised when sample is initially loaded when layer is null.
             if (_layer == null) return;
@@ -75,7 +104,9 @@ namespace ArcGIS.WPF.Samples.DisplayClusters
         private void PopupBackground_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             PopupBackground.Visibility = Visibility.Collapsed;
+            GeoElementsPanel.Visibility = Visibility.Collapsed;
             PopupViewer.Popup = null;
+            GeoElementsGrid.ItemsSource = null;
         }
     }
 }

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/readme.md
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/readme.md
@@ -33,7 +33,6 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
-
 ## Additional information
 
 Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/readme.md
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplayClusters/readme.md
@@ -33,6 +33,11 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
+
+## Additional information
+
+Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.
+
 ## Tags
 
 aggregate, bin, cluster, group, merge, normalize, reduce, summarize

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/DisplayClusters.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="ArcGIS.WinUI.Samples.DisplayClusters.DisplayClusters"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:communityTK="using:CommunityToolkit.WinUI.UI.Controls"
              xmlns:esriTK="using:Esri.ArcGISRuntime.Toolkit.UI.Controls"
              xmlns:esriUI="using:Esri.ArcGISRuntime.UI.Controls">
     <Grid>
@@ -14,13 +15,44 @@
         <Grid x:Name="PopupBackground"
               Background="#AA333333"
               Visibility="Collapsed">
-            <Border HorizontalAlignment="Center" VerticalAlignment="Center">
+            <StackPanel MaxWidth="600"
+                        MaxHeight="500"
+                        Margin="5"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Background="White">
                 <esriTK:PopupViewer x:Name="PopupViewer"
-                                    MaxWidth="400"
-                                    MaxHeight="400"
                                     Margin="5"
                                     Padding="5" />
-            </Border>
+                <StackPanel x:Name="GeoElementsPanel"
+                            Margin="5,0,5,5"
+                            Visibility="Collapsed">
+                    <TextBlock Padding="10,0,10,5"
+                               FontWeight="Bold"
+                               Text="Contained Geoelements:" />
+                    <communityTK:DataGrid x:Name="GeoElementsGrid"
+                                          MaxHeight="250"
+                                          Margin="10,5"
+                                          AutoGenerateColumns="False"
+                                          HorizontalScrollBarVisibility="Visible"
+                                          IsReadOnly="True">
+                        <communityTK:DataGrid.Columns>
+                            <communityTK:DataGridTextColumn Binding="{Binding Path=Attributes[objectid]}" 
+                                                            Width="auto"
+                                                            Header="Object ID" />
+                            <communityTK:DataGridTextColumn Binding="{Binding Path=Attributes[name]}" 
+                                                            Width="auto"
+                                                            Header="Name" />
+                            <communityTK:DataGridTextColumn Binding="{Binding Path=Attributes[capacity_mw]}" 
+                                                            Width="auto"
+                                                            Header="Capacity (MW)" />
+                            <communityTK:DataGridTextColumn Width="auto"
+                                                            Binding="{Binding Path=Attributes[fuel1]}"
+                                                            Header="Fuel" />
+                        </communityTK:DataGrid.Columns>
+                    </communityTK:DataGrid>
+                </StackPanel>
+            </StackPanel>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/readme.md
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/readme.md
@@ -33,7 +33,6 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
-
 ## Additional information
 
 Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/readme.md
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters/readme.md
@@ -33,6 +33,11 @@ Pan and zoom the map to view how clustering is dynamically updated. Toggle clust
 
 This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44c746c1aafae001552bad23) that displays the Esri [Global Power Plants](https://www.arcgis.com/home/item.html?id=eb54b44c65b846cca12914b87b315169) feature layer with feature reduction enabled. When enabled, the aggregate features symbology shows the color of the most common power plant type, and a size relative to the average plant capacity of the cluster.
 
+
+## Additional information
+
+Graphics in a graphics overlay can also be aggregated into clusters. To do this, set the `FeatureReduction` property on the `GraphicsOverlay` to a new `ClusteringFeatureReduction`.
+
 ## Tags
 
 aggregate, bin, cluster, group, merge, normalize, reduce, summarize


### PR DESCRIPTION
# Description

Adds attribute tables for clusters. Updates readmes with graphics overlay remark. 

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
