### PR TITLE
Nullify selected sample after download cancel

### DIFF
--- a/src/MAUI/Maui.Samples/Views/WaitPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/WaitPage.xaml.cs
@@ -7,6 +7,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGIS.Samples.Managers;
+
 namespace ArcGIS
 {
     public partial class WaitPage
@@ -21,6 +23,7 @@ namespace ArcGIS
 
         private void DownloadCancelled(object sender, System.EventArgs e)
         {
+            SampleManager.Current.SelectedSample = null;
             _cancellationTokenSource.Cancel(true);
         }
 


### PR DESCRIPTION
# Description

After a user clicks the cancel download button on the wait page, a user will then be unable to select a new sample. This is because we don't nullify the selected sample upon cancel button click. Consequently, the sample loader fails to launch thereafter due to a [null check](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/blob/main/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs#L103-L107). To fix this, we should nullify the selected sample upon cancelling download.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files