### PR TITLE
MAUI search fixes

### DIFF
--- a/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
@@ -93,8 +93,6 @@ namespace ArcGIS.ViewModels
                     {
                         sampleResults.Add(new SearchResultViewModel(sample.Key, score));
                     }
-
-                    if (sampleResults.Count >= 15) break;
                 }
 
                 try
@@ -102,6 +100,11 @@ namespace ArcGIS.ViewModels
                     if (sampleResults.Count != 0)
                     {
                         sampleResults = sampleResults.OrderByDescending(sampleResults => sampleResults.Score).ThenBy(sampleResults => sampleResults.SampleName).ToList();
+                        
+                        // Limit the number of search results to 15
+                        if (sampleResults.Count > 15)
+                            sampleResults = sampleResults[0..15];
+
                         SearchItems = new ObservableCollection<SearchResultViewModel>(sampleResults);
                     }
                     else

--- a/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
@@ -17,6 +17,8 @@ namespace ArcGIS.ViewModels
 
         private static readonly HashSet<string> _commonWords = ["in", "a", "of", "the", "by", "an", "and"];
 
+        private List<SearchResultViewModel> _results;
+
         [GeneratedRegex("[^a-zA-Z0-9 -]")]
         private static partial Regex NonWordCharRegex();
 
@@ -100,7 +102,8 @@ namespace ArcGIS.ViewModels
                     if (sampleResults.Count != 0)
                     {
                         sampleResults = sampleResults.OrderByDescending(sampleResults => sampleResults.Score).ThenBy(sampleResults => sampleResults.SampleName).ToList();
-                        
+                        _results = sampleResults;
+
                         // Limit the number of search results to 15
                         if (sampleResults.Count > 15)
                             sampleResults = sampleResults[0..15];
@@ -117,6 +120,18 @@ namespace ArcGIS.ViewModels
                     Console.WriteLine(ex.ToString());
                 }
             }
+        }
+
+        [RelayCommand]
+        void BatchResults()
+        {
+            var startIndex = SearchItems.Count;
+            var endIndex = Math.Min(startIndex + 15, _results.Count);
+
+            if (endIndex >= _results.Count) return;
+
+            foreach(var result in _results[startIndex..endIndex])
+                SearchItems.Add(result);
         }
 
         private static int GetMatches(string[] contentKeywords, string[] searchKeywords)

--- a/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
@@ -27,7 +27,7 @@ namespace ArcGIS.ViewModels
             // Initialize the dictionary of sample keywords.
             foreach (var sample in SampleManager.Current.AllSamples.ToList())
             {
-                var sampleNameKeywords = GetKeywords(sample.SampleName);
+                string[] sampleNameKeywords = GetKeywords(sample.SampleName).Append(sample.FormalName.ToLower()).ToArray();
                 var categoryKeywords = GetKeywords(sample.Category);
                 var descriptionKeywords = GetKeywords(sample.Description);
                 var tagsKeywords = sample.Tags.ToArray();

--- a/src/MAUI/Maui.Samples/Views/SearchPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/SearchPage.xaml
@@ -22,6 +22,7 @@
         <CollectionView Grid.Row="1"
                         ItemsSource="{Binding SearchItems}"
                         RemainingItemsThreshold="3"
+                        ItemsUpdatingScrollMode="KeepScrollOffset"
                         RemainingItemsThresholdReachedCommand="{Binding BatchResultsCommand}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:SearchResultViewModel">

--- a/src/MAUI/Maui.Samples/Views/SearchPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/SearchPage.xaml
@@ -19,7 +19,10 @@
                 <toolkit:UserStoppedTypingBehavior MinimumLengthThreshold="0" ShouldDismissKeyboardAutomatically="False" />
             </SearchBar.Behaviors>
         </SearchBar>
-        <CollectionView Grid.Row="1" ItemsSource="{Binding SearchItems}">
+        <CollectionView Grid.Row="1"
+                        ItemsSource="{Binding SearchItems}"
+                        RemainingItemsThreshold="3"
+                        RemainingItemsThresholdReachedCommand="{Binding BatchResultsCommand}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:SearchResultViewModel">
                     <Border MaximumHeightRequest="120" StrokeThickness="0">


### PR DESCRIPTION
# Description

- Fixes bug introduced in https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/pull/1457 which prevented score calculation of every sample.
- Adds a sample name keyword for sample name as it appears in code, i.e., `CreateAndEditGeometries`.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
