### PR TITLE
Change ILDS constructor

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -38,9 +38,6 @@ namespace ArcGIS.Samples.IndoorPositioning
 
         private const string ItemId = "YOUR_ITEM_ID_HERE";
 
-        private const string PositioningTableName = "IPS_Positioning";
-        private const string PathwaysLayerName = "Pathways";
-
         private string[] _layerNames = new string[] { "Details", "Units", "Levels" };
 
         #endregion BuildingData

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -133,7 +133,7 @@ namespace ArcGIS.Samples.IndoorPositioning
             labelText += $"Horizontal accuracy: {string.Format("{0:0.##}", loc.HorizontalAccuracy)}m";
 
             // Update UI on the main thread.
-            Dispatcher.Dispatch(() =>
+            Dispatcher.DispatchAsync(() =>
             {
                 PositioningLabel.Text = labelText;
             });

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -80,31 +80,8 @@ namespace ArcGIS.Samples.IndoorPositioning
 
                 PositioningLabel.Text = "Creating indoors location data source";
 
-                // Get the positioning table from the map.
-                await Task.WhenAll(MyMapView.Map.Tables.Select(table => table.LoadAsync()));
-                FeatureTable positioningTable = MyMapView.Map.Tables.Single(table => table.TableName.Equals(PositioningTableName));
-
-                // Get a table of all of the indoor pathways.
-                FeatureLayer pathwaysFeatureLayer = MyMapView.Map.OperationalLayers.OfType<FeatureLayer>().Single(l => l.Name.Equals(PathwaysLayerName, StringComparison.InvariantCultureIgnoreCase));
-                ArcGISFeatureTable pathwaysTable = pathwaysFeatureLayer.FeatureTable as ArcGISFeatureTable;
-
-                // Get the global ID for positioning. The ID identifies a specific row in the feature table that should be used for setting up IPS. We use this ID to construct the data source.
-                Field dateCreatedFieldName = positioningTable.Fields.Single(f => f.Name.Equals("DateCreated", StringComparison.InvariantCultureIgnoreCase) || f.Name.Equals("DATE_CREATED", StringComparison.InvariantCultureIgnoreCase));
-
-                // Create a query for the latest created feature. This is needed for correctly constructing the IPS used in this sample. There is a constructor without an ID parameter that will attempt to automatically find the latest row.
-                QueryParameters queryParameters = new QueryParameters
-                {
-                    MaxFeatures = 1,
-                    // "1=1" will give all the features from the table.
-                    WhereClause = "1=1",
-                };
-                queryParameters.OrderByFields.Add(new OrderBy(dateCreatedFieldName.Name, SortOrder.Descending));
-
-                FeatureQueryResult queryResult = await positioningTable.QueryFeaturesAsync(queryParameters);
-                Guid globalID = (Guid)queryResult.Single().Attributes["GlobalID"];
-
-                // Create the indoor location data source using the tables and Guid.
-                _indoorsLocationDataSource = new IndoorsLocationDataSource(positioningTable, pathwaysTable, globalID);
+                // Create the indoor location data source using the IndoorPositioningDefinition from the map.
+                _indoorsLocationDataSource = new IndoorsLocationDataSource(MyMapView.Map.IndoorPositioningDefinition);
 
                 PositioningLabel.Text = "Starting IPS";
 

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
@@ -17,7 +17,7 @@ When there is no IPS beacons nearby, or other errors occur while initializing th
 ## How it works
 
 1. Load an IPS-aware map. This can be a web map hosted as a portal item in ArcGIS Online, an Enterprise Portal, or a mobile map package (.mmpk) created with ArcGIS Pro.
-2. Create and load an `IndoorsLocationDataSource` with the positioning feature table (stored with the map), then create an `IndoorsLocationDataSource` from it.
+2. Create and load an `IndoorsLocationDataSource` (stored with the map), then create an `IndoorsLocationDataSource` from it.
 3. Handle location change events to respond to floor changes or read other metadata for locations.
 4. Assign the `IndoorsLocationDataSource` to the map view's location display.
 5. Enable and disable the map view's location display using `StartAsync()` and `StopAsync()`. Device location will appear on the display as a blue dot and update as the user moves throughout the space.


### PR DESCRIPTION
# Description

- removes reference of tables in readme
- uses `IndoorPositioningDefinition` as constructor parameter

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI Android
- [ ] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
