### PR TITLE
Only show flyout on category page

### DIFF
--- a/src/MAUI/Maui.Samples/Resources/Styles/Styles.xaml
+++ b/src/MAUI/Maui.Samples/Resources/Styles/Styles.xaml
@@ -471,6 +471,7 @@
         <Setter Property="Shell.ForegroundColor" Value="White" />
         <Setter Property="Shell.TitleColor" Value="White" />
         <Setter Property="Shell.FlyoutBackground" Value="#832FBC" />
+        <Setter Property="Shell.FlyoutBehavior" Value="Disabled" />
         <Setter Property="Shell.DisabledColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="Shell.UnselectedColor" Value="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}" />
         <Setter Property="Shell.NavBarHasShadow" Value="False" />

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
@@ -6,6 +6,7 @@
              xmlns:models="clr-namespace:ArcGIS.Samples.Shared.Models"
              xmlns:viewModels="clr-namespace:ArcGIS.ViewModels"
              Title="{Binding SelectedCategory}"
+             Shell.FlyoutBehavior="Flyout"
              x:DataType="viewModels:CategoryViewModel">
 
     <ContentPage.ToolbarItems>


### PR DESCRIPTION
# Description

This ensures behavior is consistent regardless of platform. A page does not open automatically when selected from a non-category page.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
