### PR TITLE
Package upgrades

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.70" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.60" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.70" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.UWP" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.WinUI" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Speech" Version="8.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.6" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.60" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.70" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.60" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
   </ItemGroup>


### PR DESCRIPTION
# Description

- Upgrades .NET MAUI versions to v8.0.70 which resolves an exception being thrown when using a `DisplayActionSheet` on MacOS Sonoma.
- Upgrades `System.Text.Json` to v8.0.4 to address a [security advisory](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) of high severity.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement