### PR TITLE
Platform code for CategoryPage CollectionView span

### DIFF
--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
@@ -61,7 +61,7 @@
         </CollectionView.ItemsLayout>
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="viewModels:SampleViewModel">
-                <Border StrokeThickness="{OnPlatform Default=0, Android=1}">
+                <Border Margin="{OnPlatform Default=0, Android=5}" StrokeThickness="{OnPlatform Default=0, Android=1}">
                     <Border.GestureRecognizers>
                         <PointerGestureRecognizer PointerEntered="PointerGestureRecognizer_PointerEntered" />
                         <PointerGestureRecognizer PointerExited="PointerGestureRecognizer_PointerExited" />
@@ -81,6 +81,8 @@
 
                         <Button x:Name="FavoriteButton"
                                 Grid.Row="0"
+                                Margin="{OnPlatform Default=0,
+                                                    WinUI='-1'}"
                                 Padding="2"
                                 Background="#A52F2F2F"
                                 Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:CategoryViewModel}}, Path=UpdateFavoriteCommand}"

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml
@@ -6,8 +6,37 @@
              xmlns:models="clr-namespace:ArcGIS.Samples.Shared.Models"
              xmlns:viewModels="clr-namespace:ArcGIS.ViewModels"
              Title="{Binding SelectedCategory}"
-             Shell.FlyoutBehavior="Flyout"
-             x:DataType="viewModels:CategoryViewModel">
+             x:DataType="viewModels:CategoryViewModel"
+             Shell.FlyoutBehavior="Flyout">
+
+    <ContentPage.Resources>
+        <converters:SampleToBitmapConverter x:Key="SampleToBitmapConverter" />
+        <converters:BoolToFavoriteGlyphConverter x:Key="BoolToFavoriteGlyphConverter" />
+        <Style x:Key="AndroidStyle" TargetType="CollectionView">
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup>
+                        <VisualState x:Name="Horizontal">
+                            <VisualState.StateTriggers>
+                                <OrientationStateTrigger Orientation="Landscape" />
+                            </VisualState.StateTriggers>
+                            <VisualState.Setters>
+                                <Setter Property="ItemsLayout" Value="{OnIdiom Phone='VerticalGrid, 2', Tablet='VerticalGrid, 3'}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Vertical">
+                            <VisualState.StateTriggers>
+                                <OrientationStateTrigger Orientation="Portrait" />
+                            </VisualState.StateTriggers>
+                            <VisualState.Setters>
+                                <Setter Property="ItemsLayout" Value="{OnIdiom Phone='VerticalGrid, 1', Tablet='VerticalGrid, 2'}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
 
     <ContentPage.ToolbarItems>
         <ToolbarItem Clicked="SearchClicked"
@@ -20,10 +49,7 @@
                      IconImageSource="feedback.png"
                      Text="Feedback" />
     </ContentPage.ToolbarItems>
-    <ContentPage.Resources>
-        <converters:SampleToBitmapConverter x:Key="SampleToBitmapConverter" />
-        <converters:BoolToFavoriteGlyphConverter x:Key="BoolToFavoriteGlyphConverter" />
-    </ContentPage.Resources>
+
     <CollectionView x:Name="SamplesCollection"
                     BackgroundColor="Transparent"
                     ItemsSource="{Binding SamplesItems}">
@@ -31,9 +57,6 @@
             <GridItemsLayout x:Name="SamplesGridItemsLayout"
                              HorizontalItemSpacing="5"
                              Orientation="Vertical"
-                             Span="{OnPlatform Default=4,
-                                               iOS=1,
-                                               Android=1}"
                              VerticalItemSpacing="5" />
         </CollectionView.ItemsLayout>
         <CollectionView.ItemTemplate>

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
@@ -35,11 +35,15 @@ public partial class CategoryPage : ContentPage
         {
             var numberOfColumns = (int)Math.Floor(Width / _viewModel.SampleImageWidth);
 #if IOS || MACCATALYST
-            SamplesCollection.ItemsLayout = new GridItemsLayout(numberOfColumns, ItemsLayoutOrientation.Vertical)
+            // Don't update the layout when column count is the same, for example, when app height changes on Mac.
+            if (numberOfColumns != (SamplesCollection.ItemsLayout as GridItemsLayout)?.Span)
             {
-                HorizontalItemSpacing = 5,
-                VerticalItemSpacing = 5
-            };
+                SamplesCollection.ItemsLayout = new GridItemsLayout(numberOfColumns, ItemsLayoutOrientation.Vertical)
+                {
+                    HorizontalItemSpacing = 5,
+                    VerticalItemSpacing = 5
+                };
+            }
 #elif WINDOWS
             SamplesGridItemsLayout.Span = numberOfColumns;
 #endif

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
@@ -27,22 +27,26 @@ public partial class CategoryPage : ContentPage
         BindingContext = _viewModel;
 
         WeakReferenceMessenger.Default.Register<string>(this, (message, category) => ScrollToTop());
+
+        // Handle platform differences in updating the layout.
 #if !ANDROID
+        // Event raised during an orientation state change or window resize. 
         SizeChanged += (s, e) =>
         {
+            var numberOfColumns = (int)Math.Floor(Width / _viewModel.SampleImageWidth);
 #if IOS || MACCATALYST
-            var numberOfColumns = Math.Floor(Width / _viewModel.SampleImageWidth);
-            var layout = new GridItemsLayout((int)numberOfColumns, ItemsLayoutOrientation.Vertical);
-            layout.HorizontalItemSpacing = 5;
-            layout.VerticalItemSpacing = 5;
-            SamplesCollection.ItemsLayout = layout;
+            SamplesCollection.ItemsLayout = new GridItemsLayout(numberOfColumns, ItemsLayoutOrientation.Vertical)
+            {
+                HorizontalItemSpacing = 5,
+                VerticalItemSpacing = 5
+            };
 #elif WINDOWS
-            var numberOfColumns = Math.Floor(Width / _viewModel.SampleImageWidth);
-            SamplesGridItemsLayout.Span = (int)numberOfColumns;
+            SamplesGridItemsLayout.Span = numberOfColumns;
 #endif
         };
+#else
+        SamplesCollection.Style = Resources["AndroidStyle"] as Style;
 #endif
-
     }
 
     private async void FeedbackToolbarItem_Clicked(object sender, EventArgs e)


### PR DESCRIPTION
# Description

- Adds Android-specific style to allow span to be set upon device orientation state change. Previously, there was excessive whitespace when using an Android tablet.
- Prevents unnecessary resetting of layout on Mac, for example, when changing app height.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files