### PR TITLE
WinUI Viewer: Fix NRE due to unexpected null SelectedSample

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
@@ -160,6 +160,7 @@ namespace ArcGIS.WinUI.Viewer
             {
                 // Failed to create new instance of the sample.
                 SamplePageContainer.Visibility = Visibility.Collapsed;
+                SampleManager.Current.SelectedSample = null;
                 SampleSelectionGrid.Visibility = Visibility.Visible;
                 CategoriesTree.SelectionMode = TreeViewSelectionMode.None;
                 await new MessageDialog2(exception.Message).ShowAsync();
@@ -219,6 +220,7 @@ namespace ArcGIS.WinUI.Viewer
             // Switch to the sample selection grid.
             SamplePageContainer.Visibility = Visibility.Collapsed;
             SamplePageContainer.Content = null;
+            SampleManager.Current.SelectedSample = null;
             SampleSelectionGrid.Visibility = Visibility.Visible;
         }
 
@@ -235,6 +237,7 @@ namespace ArcGIS.WinUI.Viewer
             {
                 SamplePageContainer.Visibility = Visibility.Collapsed;
                 SamplePageContainer.Content = null;
+                SampleManager.Current.SelectedSample = null;
                 SampleSelectionGrid.Visibility = Visibility.Visible;
                 List<SampleInfo> samples = selected.Children.ToList().Select(x => (SampleInfo)x.Content).ToList();
                 SamplesGridView.ItemsSource = samples;

--- a/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/SamplePage.xaml.cs
@@ -101,8 +101,6 @@ namespace ArcGIS.WinUI.Viewer
                 }
                 else if (geoView is SceneView sceneView) sceneView.Scene = null;
             }
-
-            SampleManager.Current.SelectedSample = null;
         }
 
         private static IEnumerable<T> TreeWalker<T>(UIElement root)


### PR DESCRIPTION
# Description

Problem happened when switching samples via TOC because MainPage.SelectSample and SamplePage.SamplePage_Unloaded both tried to set the SelectedSample.

## Type of change
- Sample viewer bug fix

## Platforms tested on
- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist
- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
