### PR TITLE
WinUI: Multiple fixes in FindPlace sample

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -137,6 +137,10 @@ namespace ArcGIS.Samples.FindPlace
 
             // Create the geocode parameters.
             GeocodeParameters parameters = new GeocodeParameters();
+
+            // Request that the "Address" attribute is included with results, to display in callouts.
+            parameters.ResultAttributeNames.Add("Address");
+
             try
             {
                 // Get the MapPoint for the current search location.
@@ -146,6 +150,9 @@ namespace ArcGIS.Samples.FindPlace
                 if (searchLocation != null)
                 {
                     parameters.PreferredSearchLocation = searchLocation;
+
+                    // Raise MinScore to a non-zero value, otherwise PreferredSearchLocation has no effect.
+                    parameters.MinScore = 1;
                 }
 
                 // Update the search area if desired.
@@ -174,24 +181,18 @@ namespace ArcGIS.Samples.FindPlace
 
                 // Create the GraphicsOverlay so that results can be drawn on the map.
                 GraphicsOverlay resultOverlay = new GraphicsOverlay();
+                var symbol = await GetPinSymbolAsync();
+
 
                 // Add each address to the map.
                 foreach (GeocodeResult location in locations)
                 {
                     // Get the Graphic to display.
-                    Graphic point = await GraphicForPoint(location.DisplayLocation);
+                    var point = new Graphic(location.DisplayLocation, symbol);
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-
-                    // Get the address for the point.
-                    IReadOnlyList<GeocodeResult> addresses = await _geocoder.ReverseGeocodeAsync(location.DisplayLocation);
-
-                    // Add the first suitable address if possible.
-                    if (addresses.Any())
-                    {
-                        point.Attributes["Match_Address"] = addresses.First().Label;
-                    }
+                    point.Attributes["Match_Address"] = location.Attributes["Address"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);
@@ -212,7 +213,10 @@ namespace ArcGIS.Samples.FindPlace
             }
         }
 
-        private async Task<Graphic> GraphicForPoint(MapPoint point)
+        /// <summary>
+        /// Creates and returns a "Pin" symbol used to mark search results on the MapView.
+        /// </summary>
+        private async Task<Esri.ArcGISRuntime.Symbology.Symbol> GetPinSymbolAsync()
         {
             // Get current assembly that contains the image.
             Assembly currentAssembly = Assembly.GetExecutingAssembly();
@@ -230,7 +234,7 @@ namespace ArcGIS.Samples.FindPlace
             //     is on the point rather than the image's true center.
             pinSymbol.LeaderOffsetX = 30;
             pinSymbol.OffsetY = 14;
-            return new Graphic(point, pinSymbol);
+            return pinSymbol;
         }
 
         private async void MyMapView_GeoViewTapped(object sender, Esri.ArcGISRuntime.Maui.GeoViewInputEventArgs e)

--- a/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -147,6 +147,9 @@ namespace ArcGIS.WPF.Samples.FindPlace
                 // Create the geocode parameters.
                 GeocodeParameters parameters = new GeocodeParameters();
 
+                // Request that the "Address" attribute is included with results, to display in callouts.
+                parameters.ResultAttributeNames.Add("Address");
+
                 // Get the MapPoint for the current search location.
                 MapPoint searchLocation = await GetSearchMapPoint(locationText);
 
@@ -154,6 +157,9 @@ namespace ArcGIS.WPF.Samples.FindPlace
                 if (searchLocation != null)
                 {
                     parameters.PreferredSearchLocation = searchLocation;
+
+                    // Raise MinScore to a non-zero value, otherwise PreferredSearchLocation has no effect.
+                    parameters.MinScore = 1;
                 }
 
                 // Update the search area if desired.
@@ -179,24 +185,17 @@ namespace ArcGIS.WPF.Samples.FindPlace
 
                 // Create the GraphicsOverlay so that results can be drawn on the map.
                 GraphicsOverlay resultOverlay = new GraphicsOverlay();
+                var symbol = await GetPinSymbolAsync();
 
                 // Add each address to the map.
                 foreach (GeocodeResult location in locations)
                 {
                     // Get the Graphic to display.
-                    Graphic point = await GraphicForPoint(location.DisplayLocation);
+                    var point = new Graphic(location.DisplayLocation, symbol);
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-
-                    // Get the address for the point.
-                    IReadOnlyList<GeocodeResult> addresses = await _geocoder.ReverseGeocodeAsync(location.DisplayLocation);
-
-                    // Add the first suitable address if possible.
-                    if (addresses.Any())
-                    {
-                        point.Attributes["Match_Address"] = addresses[0].Label;
-                    }
+                    point.Attributes["Match_Address"] = location.Attributes["Address"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);
@@ -218,9 +217,9 @@ namespace ArcGIS.WPF.Samples.FindPlace
         }
 
         /// <summary>
-        /// Creates and returns a Graphic associated with the given MapPoint.
+        /// Creates and returns a "Pin" symbol used to mark search results on the MapView.
         /// </summary>
-        private async Task<Graphic> GraphicForPoint(MapPoint point)
+        private async Task<Esri.ArcGISRuntime.Symbology.Symbol> GetPinSymbolAsync()
         {
             // Hold a reference to the picture marker symbol.
             PictureMarkerSymbol pinSymbol;
@@ -245,7 +244,7 @@ namespace ArcGIS.WPF.Samples.FindPlace
                 pinSymbol.OffsetY = 14;
             }
 
-            return new Graphic(point, pinSymbol);
+            return pinSymbol;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description
- Sample was individually calling ReverseGeocodeAsync to get the address, which is a slow expensive and possibly inexact operation, instead of just requesting that Address be returned with results. This was a very inefficient use the API, and potentially expensive in terms of AGOL credits.
- PictureMarkerSymbols for each result was individually reloaded and recreated over and over. This was also very inefficient.
- PreferredSearchLocation had no effect because MinScore was left at the default value of 0.

## Type of change
- Bug fix
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
