### PR TITLE
WPF and WinUI: Improve mouse-move behavior in OfflineRouting sample

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -218,7 +218,6 @@ namespace ArcGIS.WPF.Samples.OfflineRouting
                 catch (Exception e)
                 {
                     Debug.WriteLine(e);
-                    ShowMessage("Couldn't update route", "There was an error updating the route. See debug output for details.");
                 }
             } while (_parametersChangedSinceLastSolve); // Recalculate if parameters changed during execution
         }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -217,7 +217,6 @@ namespace ArcGIS.WinUI.Samples.OfflineRouting
                 catch (Exception e)
                 {
                     Debug.WriteLine(e);
-                    ShowMessage("Couldn't update route", "There was an error updating the route. See debug output for details.");
                 }
             } while (_parametersChangedSinceLastSolve); // Recalculate if parameters changed during execution
         }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -44,6 +44,8 @@ namespace ArcGIS.WinUI.Samples.OfflineRouting
         // Route task and parameters.
         private RouteTask _offlineRouteTask;
         private RouteParameters _offlineRouteParameters;
+        private bool _parametersChangedSinceLastSolve = false;
+        private Task<RouteResult> _lastSolveTask = null;
 
         // Track the graphic being interacted with.
         private Graphic _selectedStopGraphic;
@@ -148,51 +150,76 @@ namespace ArcGIS.WinUI.Samples.OfflineRouting
 
         private async Task UpdateRoute(TravelMode selectedTravelMode)
         {
-            try
+            // Create a list of stops.
+            List<Stop> stops = new List<Stop>();
+
+            // Add a stop to the list for each graphic in the stops overlay.
+            foreach (Graphic stopGraphic in _stopsOverlay.Graphics)
             {
-                // Create a list of stops.
-                List<Stop> stops = new List<Stop>();
-
-                // Add a stop to the list for each graphic in the stops overlay.
-                foreach (Graphic stopGraphic in _stopsOverlay.Graphics)
-                {
-                    Stop stop = new Stop((MapPoint)stopGraphic.Geometry);
-                    stops.Add(stop);
-                }
-
-                if (stops.Count < 2)
-                {
-                    // Don't route, there's no where to go (and the route task would throw an exception).
-                    return;
-                }
-
-                // Configure the route parameters with the list of stops.
-                _offlineRouteParameters.SetStops(stops);
-
-                // Configure the travel mode.
-                _offlineRouteParameters.TravelMode = selectedTravelMode;
-
-                // Solve the route.
-                RouteResult offlineRouteResult = await _offlineRouteTask.SolveRouteAsync(_offlineRouteParameters);
-
-                // Clear the old route result.
-                _routeOverlay.Graphics.Clear();
-
-                // Get the geometry from the route result.
-                Polyline routeGeometry = offlineRouteResult.Routes.First().RouteGeometry;
-
-                // Note: symbology left out here because the symbology was set once on the graphics overlay.
-                Graphic routeGraphic = new Graphic(routeGeometry);
-
-                // Display the route.
-                _routeOverlay.Graphics.Add(routeGraphic);
+                Stop stop = new Stop((MapPoint)stopGraphic.Geometry);
+                stops.Add(stop);
             }
-            catch (Exception e)
+
+            if (stops.Count < 2)
             {
-                Debug.WriteLine(e);
-                ShowMessage("Couldn't update route", "There was an error updating the route. See debug output for details.");
-                _selectedStopGraphic = null;
+                // Don't route, there's no where to go (and the route task would throw an exception).
+                return;
             }
+
+            // Configure the route parameters with the list of stops.
+            _offlineRouteParameters.SetStops(stops);
+
+            // Configure the travel mode.
+            _offlineRouteParameters.TravelMode = selectedTravelMode;
+            
+            // Check if a route calculation is already in progress
+            if (_lastSolveTask == null || _lastSolveTask.IsCompleted)
+            {
+                // No calculation in progress, start a new one
+                await SolveRouteAndDisplayResultsAsync();
+            }
+            else
+            {
+                // Route calculation already in progress, flag for recalculation when current task completes
+                _parametersChangedSinceLastSolve = true;
+            }
+        }
+
+        private async Task SolveRouteAndDisplayResultsAsync()
+        {
+            do
+            {
+                try
+                {
+                    // Start the route calculation
+                    _lastSolveTask = _offlineRouteTask.SolveRouteAsync(_offlineRouteParameters);
+
+                    // Reset the flag immediately after starting the task.
+                    // This ensures that any parameter changes made after this point will be caught for the next iteration.
+                    _parametersChangedSinceLastSolve = false;
+                    
+                    // By awaiting here, we allow the UI to remain responsive while route calculation is in progress.
+                    // Any changes to parameters during this await will have set _parametersChangedSinceTaskRun to true.
+                    RouteResult offlineRouteResult = await _lastSolveTask;
+
+                    // Clear the old route result.
+                    _routeOverlay.Graphics.Clear();
+
+                    // Get the geometry from the route result.
+                    Polyline routeGeometry = offlineRouteResult.Routes.First().RouteGeometry;
+
+                    // Note: symbology left out here because the symbology was set once on the graphics overlay.
+                    Graphic routeGraphic = new Graphic(routeGeometry);
+
+                    // Display the route.
+                    _routeOverlay.Graphics.Add(routeGraphic);
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine(e);
+                    ShowMessage("Couldn't update route", "There was an error updating the route. See debug output for details.");
+                }
+            } while (_parametersChangedSinceLastSolve); // Recalculate if parameters changed during execution
         }
 
         private async Task AddStop(Point tappedPosition)


### PR DESCRIPTION
# Description

This sample calls an async UpdateRoute method on MouseMoved event, but does not wait for it to finish. That causes multiple parallel calls to UpdateRoute to execute at the same time -- I've seen as many as 10 in parallel. The implications of that are:

1) The sample burns system resources and can appear unresponsive
2) The shared _offlineRouteParameters are used in a thread-unsafe way
3) There is no guarantee that most-recent call to UpdateRoute is the one that completes last -- instead, whichever of the parallel calls take the longest get to update the graphics last.

To improve on this, I added some rudimentary guards against parallel execution to the samples.  The sample feels much more responsive with these changes, and does not lock up any more:


https://github.com/user-attachments/assets/05a21202-1845-41f2-8e10-0496f8d1f2e0

MAUI sample did not need any changes, because it does not update route on mouse-move.

Note that most changes in the PR are due to indentation, and ignoring whitespace changes makes for a more readable diff: https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/pull/1490/files?w=1

## Type of change

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
