### PR TITLE
[.NET MAUI] Focus search bar automatically on search page 

### DIFF
--- a/src/MAUI/Maui.Samples/Views/SearchPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SearchPage.xaml.cs
@@ -13,7 +13,15 @@ public partial class SearchPage : ContentPage
 		InitializeComponent();
         _viewModel = new SearchViewModel();
         BindingContext = _viewModel;
-	}
+
+        // Focus search bar when page loads.
+        SampleSearchBar.Loaded += SampleSearchBar_Loaded;
+    }
+
+    private void SampleSearchBar_Loaded(object sender, EventArgs e)
+    {
+        SampleSearchBar.Focus();
+    }
 
     private void TapGestureRecognizer_SearchResultTapped(object sender, TappedEventArgs e)
     {


### PR DESCRIPTION
# Description

It's a better experience to automatically have the search bar focused when navigating to the search page.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
