### PR TITLE
Source code not displaying

### DIFF
--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -96,6 +96,7 @@
     <MauiAsset Include="Converters\*.cs" />
     <MauiImage Include="Samples\**\*.jpg" />
     <MauiAsset Include="Samples\**\*.cs" />
+    <MauiAsset Include="Samples\**\*.xaml" />
     <EmbeddedResource Include="SyntaxHighlighting\highlight.js" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -638,6 +638,10 @@ namespace ArcGIS
             {
                 string baseContent = SourceCode = string.Empty;
                 var assembly = Assembly.GetExecutingAssembly();
+
+                // Account for case sensitivity in file paths.
+                _path = _path.Replace("Networkanalysis", "NetworkAnalysis");
+                _path = _path.Replace("Utilitynetwork", "UtilityNetwork");
 #if __ANDROID__
                 if (_path.EndsWith(".xaml"))
                 {

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -642,22 +642,10 @@ namespace ArcGIS
                 // Account for case sensitivity in file paths.
                 _path = _path.Replace("Networkanalysis", "NetworkAnalysis");
                 _path = _path.Replace("Utilitynetwork", "UtilityNetwork");
-#if __ANDROID__
-                if (_path.EndsWith(".xaml"))
-                {
-                    var fileName = _path.Split('/').Last();
-                    var xamlPath = assembly.GetManifestResourceNames().Single(n => n.EndsWith($"{fileName}"));
-                    SourceCode = baseContent = await new StreamReader(assembly.GetManifestResourceStream(xamlPath)).ReadToEndAsync();
-                }
-                else
-                {
-                    using Stream fileStream = await FileSystem.Current.OpenAppPackageFileAsync(_path).ConfigureAwait(false);
-                    SourceCode = baseContent = await new StreamReader(fileStream).ReadToEndAsync();
-                }
-#else
+
                 using Stream fileStream = await FileSystem.Current.OpenAppPackageFileAsync(_path).ConfigureAwait(false);
                 SourceCode = baseContent = await new StreamReader(fileStream).ReadToEndAsync();
-#endif
+
                 // For xaml files, search for dynamic resource styles, taking into account any whitespace.
                 if (_path.EndsWith(".xaml") && String.Concat(baseContent.Where(c => !Char.IsWhiteSpace(c)))
                     .Contains("Style=\"{DynamicResource"))


### PR DESCRIPTION
# Description

- Fixes paths to `.xaml` and `.cs` files which are used in the source code viewer. Only "Network analysis" and "Utility network" samples are impacted by this bug (iOS / Android).
- Adds `MauiAsset`s for `.xaml` files, removing need for Android platform code. This fixes FileNotFound exception for Release config on Android. 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
