### PR TITLE
`CreateDynamicBasemapGallery` unhandled exception

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml.cs
@@ -62,6 +62,9 @@ namespace ArcGIS.WPF.Samples.CreateDynamicBasemapGallery
 
         private void LoadButton_Click(object sender, RoutedEventArgs e)
         {
+            // Return if no basemap style is selected.
+            if (BasemapStyleGallery.SelectedItem == null) return;
+
             // Create a new basemap style parameters object.
             var basemapStyleParameters = new BasemapStyleParameters();
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml.cs
@@ -62,6 +62,9 @@ namespace ArcGIS.WinUI.Samples.CreateDynamicBasemapGallery
 
         private void LoadButton_Click(object sender, RoutedEventArgs e)
         {
+            // Return if no basemap style is selected.
+            if (BasemapStyleGallery.SelectedItem == null) return;
+
             // Create a new basemap style parameters object.
             var basemapStyleParameters = new BasemapStyleParameters();
 


### PR DESCRIPTION
# Description

If a basemap is not selected and user tries to load, an unhandled exception occurs. Simply return if null. Note this change is included in #1496 for .NET MAUI.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files