### PR TITLE
Disable pointer hover on mobile platforms

### DIFF
--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
@@ -68,8 +68,10 @@ public partial class CategoryPage : ContentPage
         await Navigation.PushAsync(new SearchPage(), false);
     }
 
+    // The favorites icon can flicker when using a pen as pointer.
     private void PointerGestureRecognizer_PointerEntered(object sender, PointerEventArgs e)
     {
+#if WINDOWS || MACCATALYST
         var view = (Border)sender;
 
         var grid = (Grid)view.Content;
@@ -79,10 +81,12 @@ public partial class CategoryPage : ContentPage
         imageButton.IsVisible = true;
 
         Console.WriteLine("PointerRecognized");
+#endif
     }
 
     private void PointerGestureRecognizer_PointerExited(object sender, PointerEventArgs e)
     {
+ #if WINDOWS || MACCATALYST
         var view = (Border)sender;
 
         var grid = (Grid)view.Content;
@@ -92,6 +96,7 @@ public partial class CategoryPage : ContentPage
         string sampleName = (string)imageButton.CommandParameter;
 
         imageButton.IsVisible = false || SampleManager.Current.IsSampleFavorited(sampleName);
+#endif
     }
 
     protected override void OnNavigatedTo(NavigatedToEventArgs args)


### PR DESCRIPTION
# Description

Prevents flickering bug of star icon on mobile platforms which a user might be using a pen.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI Android (Samsung tablet with stylus)
- [ ] MAUI iOS (an iPad with Apple Pen needed to test)

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files