### PR TITLE
Correct API name to `ArcGISStreamServiceFilter`

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
@@ -28,7 +28,7 @@ namespace ArcGIS.Samples.AddDynamicEntityLayer
         tags: new[] { "data", "dynamic", "entity", "live", "purge", "real-time", "service", "stream", "track" })]
     public partial class AddDynamicEntityLayer
     {
-        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the `DynamicEntityFilter`.
+        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the ArcGISStreamServiceFilter.
         private Envelope _utahSandyEnvelope = new Envelope(new MapPoint(-112.110052, 40.718083, SpatialReferences.Wgs84), new MapPoint(-111.814782, 40.535247, SpatialReferences.Wgs84));
 
         private ArcGISStreamService _dynamicEntityDataSource;

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.md
@@ -26,9 +26,9 @@ Use the controls to connect to or disconnect from the stream service, modify dis
 ## Relevant API
 
 * ArcGISStreamService
+* ArcGISStreamServiceFilter
 * ConnectionStatus
 * DynamicEntity
-* DynamicEntityFilter
 * DynamicEntityLayer
 * DynamicEntityPurgeOptions
 * TrackDisplayProperties

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
@@ -23,9 +23,9 @@
     ],
     "relevant_apis": [
         "ArcGISStreamService",
+        "ArcGISStreamServiceFilter",
         "ConnectionStatus",
         "DynamicEntity",
-        "DynamicEntityFilter",
         "DynamicEntityLayer",
         "DynamicEntityPurgeOptions",
         "TrackDisplayProperties"

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
@@ -27,7 +27,7 @@ namespace ArcGIS.WPF.Samples.AddDynamicEntityLayer
         tags: new[] { "data", "dynamic", "entity", "live", "purge", "real-time", "service", "stream", "track" })]
     public partial class AddDynamicEntityLayer
     {
-        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the `DynamicEntityFilter`.
+        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the ArcGISStreamServiceFilter.
         private Envelope _utahSandyEnvelope = new Envelope(new MapPoint(-112.110052, 40.718083, SpatialReferences.Wgs84), new MapPoint(-111.814782, 40.535247, SpatialReferences.Wgs84));
 
         private ArcGISStreamService _dynamicEntityDataSource;

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.md
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.md
@@ -26,9 +26,9 @@ Use the controls to connect to or disconnect from the stream service, modify dis
 ## Relevant API
 
 * ArcGISStreamService
+* ArcGISStreamServiceFilter
 * ConnectionStatus
 * DynamicEntity
-* DynamicEntityFilter
 * DynamicEntityLayer
 * DynamicEntityPurgeOptions
 * TrackDisplayProperties

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
@@ -23,9 +23,9 @@
     ],
     "relevant_apis": [
         "ArcGISStreamService",
+        "ArcGISStreamServiceFilter",
         "ConnectionStatus",
         "DynamicEntity",
-        "DynamicEntityFilter",
         "DynamicEntityLayer",
         "DynamicEntityPurgeOptions",
         "TrackDisplayProperties"

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.xaml.cs
@@ -28,7 +28,7 @@ namespace ArcGIS.WinUI.Samples.AddDynamicEntityLayer
         tags: new[] { "data", "dynamic", "entity", "live", "purge", "real-time", "service", "stream", "track" })]
     public partial class AddDynamicEntityLayer
     {
-        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the `DynamicEntityFilter`.
+        // This envelope is a limited region around Sandy, Utah. It will be the extent used by the ArcGISStreamServiceFilter.
         private Envelope _utahSandyEnvelope = new Envelope(new MapPoint(-112.110052, 40.718083, SpatialReferences.Wgs84), new MapPoint(-111.814782, 40.535247, SpatialReferences.Wgs84));
 
         private ArcGISStreamService _dynamicEntityDataSource;

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.md
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.md
@@ -26,9 +26,9 @@ Use the controls to connect to or disconnect from the stream service, modify dis
 ## Relevant API
 
 * ArcGISStreamService
+* ArcGISStreamServiceFilter
 * ConnectionStatus
 * DynamicEntity
-* DynamicEntityFilter
 * DynamicEntityLayer
 * DynamicEntityPurgeOptions
 * TrackDisplayProperties

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer/readme.metadata.json
@@ -23,9 +23,9 @@
     ],
     "relevant_apis": [
         "ArcGISStreamService",
+        "ArcGISStreamServiceFilter",
         "ConnectionStatus",
         "DynamicEntity",
-        "DynamicEntityFilter",
         "DynamicEntityLayer",
         "DynamicEntityPurgeOptions",
         "TrackDisplayProperties"


### PR DESCRIPTION
Fixes the API name in the metadata, code comments, and readme:
`DynamicEntityFilter` -> `ArcGISStreamServiceFilter`