### PR TITLE
Temporarily disable UWP builds

### DIFF
--- a/tools/GenerateApps.msbuild
+++ b/tools/GenerateApps.msbuild
@@ -95,6 +95,6 @@
         <MakeDir Directories="$(MSBuildThisFileDirectory)..\output" />
     </Target>
 
-  <Target Name="BuildAll" DependsOnTargets="BuildWPF;BuildWinUI;BuildMaui;BuildUWP" />
+  <Target Name="BuildAll" DependsOnTargets="BuildWPF;BuildWinUI;BuildMaui" />
 
 </Project>


### PR DESCRIPTION
# Description

Temporarily disabling UWP builds failing to link in CI builds

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
