### PR TITLE
Update authentication call and corrected minor warnings

### DIFF
--- a/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
@@ -74,23 +74,6 @@ namespace ArcGIS.Helpers
             AuthenticationManager.Current.OAuthUserConfigurations.Add(userConfig);
             AuthenticationManager.Current.OAuthAuthorizeHandler = new OAuthAuthorize();
         }
-
-        // ChallengeHandler function that will be called whenever access to a secured resource is attempted.
-        public static async Task<Credential> PromptCredentialAsync(CredentialRequestInfo info)
-        {
-            Credential credential = null;
-
-            try
-            {
-                // IOAuthAuthorizeHandler will challenge the user for OAuth credentials.
-                credential = await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri);
-            }
-            // OAuth login was canceled, no need to display error to user.
-            catch (TaskCanceledException) { }
-            catch (OperationCanceledException) { }
-
-            return credential;
-        }
     }
 
     #region IOAuthAuthorizationHandler implementation

--- a/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -50,7 +50,7 @@ namespace ArcGIS.Samples.EditBranchVersioning
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
@@ -103,7 +103,7 @@ namespace ArcGIS.Samples.DisplayFeatureLayers
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -50,7 +50,7 @@ namespace ArcGIS.Samples.DisplaySubtypeFeatureLayer
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
@@ -73,11 +73,7 @@ namespace ArcGIS.Samples.FilterFeaturesInScene
             _sceneLayerExtentPolygon = builder.ToGeometry();
 
             // Create the SceneLayerPolygonFilter to later apply to the OSM buildings layer.
-            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter()
-            {
-                SpatialRelationship = SceneLayerPolygonFilterSpatialRelationship.Disjoint
-            };
-            _sceneLayerPolygonFilter.Polygons.Add(builder.ToGeometry());
+            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter(new List<Polygon>() { builder.ToGeometry() }, SceneLayerPolygonFilterSpatialRelationship.Disjoint);
 
             // Create the extent graphic so we can add it later with the detailed buildings scene layer.
             var simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 5.0f);

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -121,11 +121,10 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
                 CredentialRequestInfo requestInfo = (CredentialRequestInfo)_loginTaskCompletionSrc.Task.AsyncState;
 
                 // Create a token credential using the provided username and password.
-                TokenCredential userCredentials = await AuthenticationManager.Current.GenerateCredentialAsync
+                AccessTokenCredential userCredentials = await AccessTokenCredential.CreateAsync
                                             (requestInfo.ServiceUri,
                                              e.Username,
-                                             e.Password,
-                                             requestInfo.GenerateTokenOptions);
+                                             e.Password);
 
                 // Set the task completion source result with the ArcGIS network credential.
                 // AuthenticationManager is waiting for this result and will add it to its Credentials collection.

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGIS.Samples.ConfigureSubnetworkTrace
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.CreateLoadReport
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -60,7 +60,7 @@ namespace ArcGIS.Samples.DisplayUtilityAssociations
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
@@ -53,7 +53,7 @@ namespace ArcGIS.Samples.DisplayUtilityNetworkContainer
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGIS.Samples.PerformValveIsolationTrace
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
@@ -110,9 +110,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
                     "https://sampleserver7.arcgisonline.com/portal/sharing/rest";
                 string sampleServer7User = "editor01";
                 string sampleServer7Pass = "S7#i2LWmYH75";
-                var credential = await AuthenticationManager
-                    .Current
-                    .GenerateCredentialAsync(
+                var credential = await AccessTokenCredential.CreateAsync(
                         new Uri(sampleServerPortalUrl),
                         sampleServer7User,
                         sampleServer7Pass

--- a/src/WPF/WPF.Viewer/Helpers/ArcGISLoginPrompt.cs
+++ b/src/WPF/WPF.Viewer/Helpers/ArcGISLoginPrompt.cs
@@ -67,24 +67,6 @@ namespace ArcGIS.Helpers
             return loggedIn;
         }
 
-        // ChallengeHandler function that will be called whenever access to a secured resource is attempted
-        public static async Task<Credential> PromptCredentialAsync(CredentialRequestInfo info)
-        {
-            Credential credential = null;
-
-            try
-            {
-                // IOAuthAuthorizeHandler will challenge the user for OAuth credentials
-                credential = await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri);
-            }
-            catch (OperationCanceledException)
-            {
-                // OAuth login was canceled, no need to display error to user.
-            }
-
-            return credential;
-        }
-
         public static void SetChallengeHandler()
         {
             var userConfig = new OAuthUserConfiguration(new Uri(ArcGISOnlineUrl), AppClientId, new Uri(OAuthRedirectUrl));

--- a/src/WPF/WPF.Viewer/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -54,7 +54,7 @@ namespace ArcGIS.WPF.Samples.EditBranchVersioning
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
@@ -107,7 +107,7 @@ namespace ArcGIS.WPF.Samples.DisplayFeatureLayers
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -52,7 +52,7 @@ namespace ArcGIS.WPF.Samples.DisplaySubtypeFeatureLayer
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -76,11 +77,7 @@ namespace ArcGIS.WPF.Samples.FilterFeaturesInScene
             _sceneLayerExtentPolygon = builder.ToGeometry();
 
             // Create the SceneLayerPolygonFilter to later apply to the OSM buildings layer.
-            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter()
-            {
-                SpatialRelationship = SceneLayerPolygonFilterSpatialRelationship.Disjoint
-            };
-            _sceneLayerPolygonFilter.Polygons.Add(builder.ToGeometry());
+            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter(new List<Polygon>() { builder.ToGeometry() }, SceneLayerPolygonFilterSpatialRelationship.Disjoint);
 
             // Create the extent graphic so we can add it later with the detailed buildings scene layer.
             var simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 5.0f);

--- a/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -96,11 +96,10 @@ namespace ArcGIS.WPF.Samples.TokenSecuredChallenge
             try
             {
                 // Create a token credential using the provided username and password.
-                TokenCredential userCredentials = await AuthenticationManager.Current.GenerateCredentialAsync
+                AccessTokenCredential userCredentials = await AccessTokenCredential.CreateAsync
                                             (new Uri(loginEntry.ServiceUrl),
                                              loginEntry.UserName,
-                                             loginEntry.Password,
-                                             loginEntry.RequestInfo.GenerateTokenOptions);
+                                             loginEntry.Password);
 
                 // Set the result on the task completion source.
                 _loginTaskCompletionSource.TrySetResult(userCredentials);

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
@@ -67,7 +67,7 @@ namespace ArcGIS.WPF.Samples.ConfigureSubnetworkTrace
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGIS.WPF.Samples.CreateLoadReport
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGIS.WPF.Samples.DisplayUtilityAssociations
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
@@ -58,7 +58,7 @@ namespace ArcGIS.WPF.Samples.DisplayUtilityNetworkContainer
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGIS.WPF.Samples.PerformValveIsolationTrace
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -73,7 +73,7 @@ namespace ArcGIS.WPF.Samples.TraceUtilityNetwork
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
@@ -114,9 +114,7 @@ namespace ArcGIS.WPF.Samples.ValidateUtilityNetworkTopology
                     "https://sampleserver7.arcgisonline.com/portal/sharing/rest";
                 string sampleServer7User = "editor01";
                 string sampleServer7Pass = "S7#i2LWmYH75";
-                var credential = await AuthenticationManager
-                    .Current
-                    .GenerateCredentialAsync(
+                var credential = await AccessTokenCredential.CreateAsync(
                         new Uri(sampleServerPortalUrl),
                         sampleServer7User,
                         sampleServer7Pass

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Helpers/ArcGISLoginPrompt.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Helpers/ArcGISLoginPrompt.cs
@@ -68,24 +68,6 @@ namespace ArcGIS.Helpers
             return loggedIn;
         }
 
-        // ChallengeHandler function that will be called whenever access to a secured resource is attempted
-        public static async Task<Credential> PromptCredentialAsync(CredentialRequestInfo info)
-        {
-            Credential credential = null;
-
-            try
-            {
-                // IOAuthAuthorizeHandler will challenge the user for OAuth credentials
-                credential = await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri);
-            }
-            catch (OperationCanceledException)
-            {
-                // OAuth login was canceled, no need to display error to user.
-            }
-
-            return credential;
-        }
-
         public static void SetChallengeHandler(UserControl sample)
         {
             var userConfig = new OAuthUserConfiguration(new Uri(ArcGISOnlineUrl), AppClientId, new Uri(OAuthRedirectUrl));


### PR DESCRIPTION
# Description

Removed deprecated authentication call `AuthenticationManager.Current.GenerateCredentialAsync()` in favor of new `AccessTokenCredential.CreateAsync()`.

Corrected other minor warnings.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
