### PR TITLE
Dialogs when running AnimateImageOverlay sample in x86

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -41,11 +41,18 @@ namespace ArcGIS.Samples.AnimateImageOverlay
         public AnimateImageOverlay()
         {
             InitializeComponent();
-            Initialize();
+            _ = Initialize();
         }
 
-        private void Initialize()
+        private async Task Initialize()
         {
+            // This sample is only supported in x64 on .NET MAUI.
+            if (!Environment.Is64BitProcess)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "This sample is only supported for .NET MAUI in x64. Run the sample viewer in x64 to use this sample.", "Exit");
+                return;
+            }
+
             // Create the scene.
             MySceneView.Scene = new Scene(BasemapStyle.ArcGISDarkGray);
 
@@ -137,7 +144,7 @@ namespace ArcGIS.Samples.AnimateImageOverlay
         {
             //Stop the animation when the sample is unloaded.
             _animationStopped = true;
-            _timer.Dispose();
+            _timer?.Dispose();
         }
     }
 }

--- a/src/WPF/WPF.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -52,6 +52,12 @@ namespace ArcGIS.WPF.Samples.AnimateImageOverlay
 
         private void Initialize()
         {
+            // This sample is only supported in x64 on WPF.
+            if (!Environment.Is64BitProcess)
+            {
+                MessageBox.Show("This sample is only supported for WPF in x64. Run the sample viewer in x64 to use this sample.");
+            }
+
             // Create the scene.
             MySceneView.Scene = new Scene(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")));
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -53,10 +53,10 @@ namespace ArcGIS.WinUI.Samples.AnimateImageOverlay
 
         private async Task Initialize()
         {
-            // This sample is only supported in x64 on UWP.
+            // This sample is only supported in x64 on WinUI.
             if (!Environment.Is64BitProcess)
             {
-                await new MessageDialog2("This sample is only supported for UWP in x64. Run the sample viewer in x64 to use this sample.", "Error").ShowAsync();
+                await new MessageDialog2("This sample is only supported for WinUI in x64. Run the sample viewer in x64 to use this sample.", "Error").ShowAsync();
                 return;
             }
 


### PR DESCRIPTION
# Description

Display dialog to not use AnimateImageOverlay sample when in x86

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)