### PR TITLE
Update authentication call on WinUI to reduce warnings

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGIS.WinUI.Samples.EditBranchVersioning
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
@@ -107,7 +107,7 @@ namespace ArcGIS.WinUI.Samples.DisplayFeatureLayers
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -51,7 +51,7 @@ namespace ArcGIS.WinUI.Samples.DisplaySubtypeFeatureLayer
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Scene/FilterFeaturesInScene/FilterFeaturesInScene.xaml.cs
@@ -13,6 +13,7 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using Microsoft.UI.Xaml;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Geometry = Esri.ArcGISRuntime.Geometry.Geometry;
@@ -76,11 +77,7 @@ namespace ArcGIS.WinUI.Samples.FilterFeaturesInScene
             _sceneLayerExtentPolygon = builder.ToGeometry();
 
             // Create the SceneLayerPolygonFilter to later apply to the OSM buildings layer.
-            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter()
-            {
-                SpatialRelationship = SceneLayerPolygonFilterSpatialRelationship.Disjoint
-            };
-            _sceneLayerPolygonFilter.Polygons.Add(builder.ToGeometry());
+            _sceneLayerPolygonFilter = new SceneLayerPolygonFilter(new List<Polygon>() { builder.ToGeometry() }, SceneLayerPolygonFilterSpatialRelationship.Disjoint);
 
             // Create the extent graphic so we can add it later with the detailed buildings scene layer.
             var simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Red, 5.0f);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -157,11 +157,10 @@ namespace ArcGIS.WinUI.Samples.TokenSecuredChallenge
             try
             {
                 // Create a token credential using the provided username and password.
-                TokenCredential userCredentials = await AuthenticationManager.Current.GenerateCredentialAsync
+                Credential userCredentials = await AccessTokenCredential.CreateAsync
                                             (new Uri(loginEntry.ServiceUrl),
                                              loginEntry.UserName,
-                                             loginEntry.Password,
-                                             loginEntry.RequestInfo.GenerateTokenOptions);
+                                             loginEntry.Password);
 
                 // Set the result on the task completion source.
                 _loginTaskCompletionSource.TrySetResult(userCredentials);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGIS.WinUI.Samples.ConfigureSubnetworkTrace
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGIS.WinUI.Samples.CreateLoadReport
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "editor01";
                     string sampleServer7Pass = "S7#i2LWmYH75";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -63,7 +63,7 @@ namespace ArcGIS.WinUI.Samples.DisplayUtilityAssociations
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
@@ -59,7 +59,7 @@ namespace ArcGIS.WinUI.Samples.DisplayUtilityNetworkContainer
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGIS.WinUI.Samples.PerformValveIsolationTrace
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
 
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGIS.WinUI.Samples.TraceUtilityNetwork
                     // WARNING: Never hardcode login information in a production application. This is done solely for the sake of the sample.
                     string sampleServer7User = "viewer01";
                     string sampleServer7Pass = "I68VGU^nMurF";
-                    return await AuthenticationManager.Current.GenerateCredentialAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
+                    return await AccessTokenCredential.CreateAsync(info.ServiceUri, sampleServer7User, sampleServer7Pass);
                 }
                 catch (Exception ex)
                 {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
@@ -114,9 +114,7 @@ namespace ArcGIS.WinUI.Samples.ValidateUtilityNetworkTopology
                     "https://sampleserver7.arcgisonline.com/portal/sharing/rest";
                 string sampleServer7User = "editor01";
                 string sampleServer7Pass = "S7#i2LWmYH75";
-                var credential = await AuthenticationManager
-                    .Current
-                    .GenerateCredentialAsync(
+                var credential = await AccessTokenCredential.CreateAsync(
                         new Uri(sampleServerPortalUrl),
                         sampleServer7User,
                         sampleServer7Pass


### PR DESCRIPTION
# Description

Updated authentication calls to  use `AccessTokenCredential.CreateAsync()`.
Updated `SceneLayerPolygonFilter` constructor usage in `FilterFeaturesInScene`.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
