### PR TITLE
Update WinUI Dependency

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="CommunityToolkit.Maui" Version="9.0.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageVersion Include="WinUIEx" Version="2.3.4" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240607001" Condition="'$(UseMaui)'!='true'" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />


### PR DESCRIPTION
# Description

Windows App SDK v1.6 is now required


## Type of change

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
