### PR TITLE
.csproj properties for WinUI sample viewer

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="CommunityToolkit.Maui" Version="9.0.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageVersion Include="WinUIEx" Version="2.3.4" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" Condition="'$(UseMaui)'!='true'" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" Condition="'$(UseMaui)'!='true'" />
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -30,8 +30,8 @@
 		<DefineConstants>$(DefineConstants);MAUI</DefineConstants>
 		<RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' AND '$(Platform)' == 'AnyCPU'">win10-x64</RuntimeIdentifier>
-		<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<AllowUnsafeBlocks Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">True</AllowUnsafeBlocks>
+		<WindowsSdkPackageVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.38</WindowsSdkPackageVersion>
     <AppxPackageDir>..\..\..\output\$(RuntimeIdentifier)\</AppxPackageDir>
 	</PropertyGroup>
 

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -146,6 +146,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
     <PackageReference Include="WinUIEx" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+	<PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
     <PackageReference Include="Xamarin.AndroidX.AppCompat" />

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -30,6 +30,8 @@
 		<DefineConstants>$(DefineConstants);MAUI</DefineConstants>
 		<RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' AND '$(Platform)' == 'AnyCPU'">win10-x64</RuntimeIdentifier>
+		<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AppxPackageDir>..\..\..\output\$(RuntimeIdentifier)\</AppxPackageDir>
 	</PropertyGroup>
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -15,6 +15,7 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WinUI</DefineConstants>
     <UseRidGraph>true</UseRidGraph>
+    <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -15,6 +15,7 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WinUI</DefineConstants>
     <UseRidGraph>true</UseRidGraph>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to #1543, adds properties to resolve build issues.

- `<AllowUnsafeBlocks`: 87ce28d5016f7c9f81f085790d607125c13d1305
- `WIndowsSdkPackageVersion`: 7bf65744adbf93604327e4c13a3b02fd66bd4216