### PR TITLE
Upgrade .NET MAUI to target .NET 9

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
-    <PackageVersion Include="CommunityToolkit.Maui" Version="9.0.1" />
+    <PackageVersion Include="CommunityToolkit.Maui" Version="10.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageVersion Include="WinUIEx" Version="2.3.4" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" Condition="'$(UseMaui)'!='true'" />
@@ -31,8 +31,8 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.1" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.5.0" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.70" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.70" />
-    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.21" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.21" />
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.3" />
   </ItemGroup>
 </Project>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ArcGIS.Samples</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -67,7 +67,7 @@
 	</ItemGroup>
 
 	<!-- Exclude Indoor Positioning on desktop platforms -->
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-maccatalyst')) or $(TargetFramework.StartsWith('net8.0-windows'))">
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
 	  <AndroidResource Remove="Samples\Location\IndoorPositioning\**" />
 	  <Compile Remove="Samples\Location\IndoorPositioning\**" />
 	  <MauiCss Remove="Samples\Location\IndoorPositioning\**" />
@@ -141,11 +141,11 @@
   </ItemGroup>
 
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <PackageReference Include="WinUIEx" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <PackageReference Include="Xamarin.AndroidX.AppCompat" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# Description

Upgrades .NET MAUI to target .NET 9

## Type of change

- Other enhancement

## Platforms tested on

- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes (there are new XAMLC warnings, telling us to improve bindings by using x:datatype)
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
