### PR TITLE
Upgrade appcompat package to fix build

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,6 +33,6 @@
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.21" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.21" />
-    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.3" />
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Fixes build error due to increase in dependency requirements from toolkit on Android

## Type of change

<!--- Delete any that don't apply -->

- Build fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
