### PR TITLE
Fix v.next warnings

### DIFF
--- a/src/MAUI/Maui.Samples/App.xaml.cs
+++ b/src/MAUI/Maui.Samples/App.xaml.cs
@@ -8,7 +8,11 @@ public partial class App : Application
     {
         InitializeComponent();
 
-        MainPage = new AppShell();
         Current = this;
+    }
+
+    protected override Window CreateWindow(IActivationState activationState)
+    {
+        return new Window(new AppShell());
     }
 }

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -21,7 +21,7 @@
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>

--- a/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
@@ -62,7 +62,7 @@ namespace ArcGIS.Helpers
             }
             catch (Exception ex)
             {
-                await DisplayAlert("Login failed", ex.Message, "OK");
+                await Application.Current.Windows[0].Page.DisplayAlert("Login failed", ex.Message, "OK");
             }
 
             return loggedIn;

--- a/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/ArcGISLoginPrompt.cs
@@ -62,7 +62,7 @@ namespace ArcGIS.Helpers
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Login failed", ex.Message, "OK");
+                await DisplayAlert("Login failed", ex.Message, "OK");
             }
 
             return loggedIn;

--- a/src/MAUI/Maui.Samples/Helpers/FeedbackPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/FeedbackPrompt.cs
@@ -20,7 +20,7 @@ namespace ArcGIS.Helpers
 
         public async static Task ShowFeedbackPromptAsync()
         {
-            await DisplayActionSheet("Open an issue on GitHub:", "Cancel", null, [BugReport, FeatureRequest]).ContinueWith((result) =>
+            await Application.Current.Windows[0].Page.DisplayActionSheet("Open an issue on GitHub:", "Cancel", null, [BugReport, FeatureRequest]).ContinueWith((result) =>
             {
                 switch (result.Result)
                 {

--- a/src/MAUI/Maui.Samples/Helpers/FeedbackPrompt.cs
+++ b/src/MAUI/Maui.Samples/Helpers/FeedbackPrompt.cs
@@ -20,7 +20,7 @@ namespace ArcGIS.Helpers
 
         public async static Task ShowFeedbackPromptAsync()
         {
-            await Application.Current.MainPage.DisplayActionSheet("Open an issue on GitHub:", "Cancel", null, [BugReport, FeatureRequest]).ContinueWith((result) =>
+            await DisplayActionSheet("Open an issue on GitHub:", "Cancel", null, [BugReport, FeatureRequest]).ContinueWith((result) =>
             {
                 switch (result.Result)
                 {

--- a/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
+++ b/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Helpers
                     await Shell.Current.Navigation.PopModalAsync(false);
                 }
 
-                await DisplayAlert("", "Download cancelled", "OK");
+                await Application.Current.Windows[0].Page.DisplayAlert("", "Download cancelled", "OK");
             }
             catch (Exception ex)
             {

--- a/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
+++ b/src/MAUI/Maui.Samples/Helpers/SampleLoader.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Helpers
                     await Shell.Current.Navigation.PopModalAsync(false);
                 }
 
-                await Application.Current.MainPage.DisplayAlert("", "Download cancelled", "OK");
+                await DisplayAlert("", "Download cancelled", "OK");
             }
             catch (Exception ex)
             {

--- a/src/MAUI/Maui.Samples/Platforms/iOS/Helpers/KeyboardHelper.cs
+++ b/src/MAUI/Maui.Samples/Platforms/iOS/Helpers/KeyboardHelper.cs
@@ -6,7 +6,10 @@ namespace ArcGIS.Platforms.Helpers
     {
         public static void HideKeyboard()
         {
-            UIApplication.SharedApplication.KeyWindow.EndEditing(true);
+            UIApplication.SharedApplication.ConnectedScenes
+                .OfType<UIWindowScene>()
+                .SelectMany(s => s.Windows)
+                .FirstOrDefault(w => w.IsKeyWindow).EndEditing(true);
         }
     }
 }

--- a/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
@@ -138,7 +138,7 @@ namespace ArcGIS.Samples.LineOfSightGeoElement
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -107,7 +107,7 @@ namespace ArcGIS.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -134,7 +134,7 @@ namespace ArcGIS.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
@@ -135,7 +135,7 @@ namespace ArcGIS.Samples.ViewshedGeoElement
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml
@@ -4,14 +4,15 @@
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
     <Grid>
         <esriUI:MapView x:Name="MyMapView" GeoViewTapped="MyMapView_GeoViewTapped" />
-        <Frame x:Name="FeatureAttributesPopup"
-               Margin="30"
-               Padding="0"
-               CornerRadius="0"
-               HorizontalOptions="Center"
-               IsVisible="False"
-               VerticalOptions="Start"
-               WidthRequest="300">
+        <Border x:Name="FeatureAttributesPopup"
+                Margin="30"
+                Padding="0"
+                BackgroundColor="{AppThemeBinding Dark=Black,
+                                                  Light=White}"
+                HorizontalOptions="Center"
+                IsVisible="False"
+                VerticalOptions="Start"
+                WidthRequest="300">
             <StackLayout Margin="5"
                          Padding="15"
                          Spacing="5">
@@ -46,6 +47,6 @@
                         Text="Discard"
                         WidthRequest="240" />
             </StackLayout>
-        </Frame>
+        </Border>
     </Grid>
 </ContentPage>

--- a/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/AddFeaturesWithContingentValues/AddFeaturesWithContingentValues.xaml.cs
@@ -135,7 +135,7 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 
@@ -163,7 +163,7 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -197,7 +197,7 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
 
             return contingentValuesNamesList;
@@ -250,7 +250,7 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 
@@ -274,13 +274,13 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
                         break;
 
                     default:
-                        await Application.Current.MainPage.DisplayAlert("Error", $"{field} not found in any of the data dictionaries.", "OK");
+                        await DisplayAlert("Error", $"{field} not found in any of the data dictionaries.", "OK");
                         break;
                 }
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 
@@ -344,7 +344,7 @@ namespace ArcGIS.Samples.AddFeaturesWithContingentValues
             }
             else
             {
-                await Application.Current.MainPage.DisplayAlert("Error", $"Error saving feature. {numberOfViolations} violation(s) in field group(s) {string.Join(", ", fieldGroupNames)}.", "OK");
+                await DisplayAlert("Error", $"Error saving feature. {numberOfViolations} violation(s) in field group(s) {string.Join(", ", fieldGroupNames)}.", "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml.cs
@@ -101,7 +101,7 @@ namespace ArcGIS.Samples.CreateMobileGeodatabase
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 
@@ -131,7 +131,7 @@ namespace ArcGIS.Samples.CreateMobileGeodatabase
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 
@@ -178,7 +178,7 @@ namespace ArcGIS.Samples.CreateMobileGeodatabase
             }
             catch (Exception ex)
             {
-                Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 
@@ -195,7 +195,7 @@ namespace ArcGIS.Samples.CreateMobileGeodatabase
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -131,7 +131,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -227,7 +227,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -373,7 +373,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
                 }
 
                 // Show the message.
-                await Application.Current.MainPage.DisplayAlert("Error", message, "OK");
+                await DisplayAlert("Error", message, "OK");
             }
         }
 
@@ -438,7 +438,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
             // Tell the user about job completion.
             if (job.Status == JobStatus.Succeeded)
             {
-                Application.Current.MainPage.DisplayAlert("Alert", "Geodatabase synchronization succeeded.", "OK");
+                DisplayAlert("Alert", "Geodatabase synchronization succeeded.", "OK");
             }
             // See if the job failed.
             else if (job.Status == JobStatus.Failed)
@@ -462,7 +462,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
                 }
 
                 // Show the message.
-                Application.Current.MainPage.DisplayAlert("Error", message, "OK");
+                DisplayAlert("Error", message, "OK");
             }
         }
 
@@ -481,7 +481,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -512,7 +512,7 @@ namespace ArcGIS.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                await DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -178,7 +178,7 @@ namespace ArcGIS.Samples.EditBranchVersioning
 
         private void ShowAlert(string alertText, string titleText = "Alert")
         {
-            Application.Current.MainPage.DisplayAlert(titleText, alertText, "OK");
+            DisplayAlert(titleText, alertText, "OK");
         }
 
         private async void MyMapView_GeoViewTapped(object sender, Esri.ArcGISRuntime.Maui.GeoViewInputEventArgs e)

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -27,6 +27,7 @@ namespace ArcGIS.Samples.EditFeatureAttachments
         tags: new[] { "JPEG", "PDF", "PNG", "TXT", "data", "image", "picture" })]
     public partial class EditFeatureAttachments : ContentPage
     {
+#pragma warning disable CA1422
         // URL to the feature service.
         private const string FeatureServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
@@ -419,4 +420,5 @@ namespace ArcGIS.Samples.EditFeatureAttachments
         }
 #endif
     }
+#pragma warning restore CA1422
 }

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -27,7 +27,6 @@ namespace ArcGIS.Samples.EditFeatureAttachments
         tags: new[] { "JPEG", "PDF", "PNG", "TXT", "data", "image", "picture" })]
     public partial class EditFeatureAttachments : ContentPage
     {
-#pragma warning disable CA1422
         // URL to the feature service.
         private const string FeatureServiceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0";
 
@@ -287,8 +286,10 @@ namespace ArcGIS.Samples.EditFeatureAttachments
             // Create and define UIImagePickerController.
             _imagePicker = new UIImagePickerController
             {
+#pragma warning disable CA1422
                 SourceType = UIImagePickerControllerSourceType.PhotoLibrary,
                 MediaTypes = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.PhotoLibrary)
+#pragma warning restore CA1422
             };
 
             // Set event handlers.
@@ -296,7 +297,10 @@ namespace ArcGIS.Samples.EditFeatureAttachments
             _imagePicker.Canceled += OnImagePickerCancelled;
 
             // Present UIImagePickerController.
-            UIWindow window = UIApplication.SharedApplication.KeyWindow;
+            UIWindow window = UIApplication.SharedApplication.ConnectedScenes
+                .OfType<UIWindowScene>()
+                .SelectMany(s => s.Windows)
+                .FirstOrDefault(w => w.IsKeyWindow);
             var viewController = window.RootViewController;
             viewController.PresentViewController(_imagePicker, true, null);
 
@@ -364,7 +368,10 @@ namespace ArcGIS.Samples.EditFeatureAttachments
             _imagePicker.WasCancelled += DocumentCancelled;
 
             // Present the UIDocumentPickerViewController.
-            UIWindow window = UIApplication.SharedApplication.KeyWindow;
+            UIWindow window = UIApplication.SharedApplication.ConnectedScenes
+                .OfType<UIWindowScene>()
+                .SelectMany(s => s.Windows)
+                .FirstOrDefault(w => w.IsKeyWindow);
             var viewController = window.RootViewController;
             viewController.PresentViewController(_imagePicker, true, null);
 
@@ -420,5 +427,4 @@ namespace ArcGIS.Samples.EditFeatureAttachments
         }
 #endif
     }
-#pragma warning restore CA1422
 }

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGIS.Samples.EditFeatureAttachments
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -110,7 +110,7 @@ namespace ArcGIS.Samples.EditFeatureAttachments
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error selecting feature", ex.ToString(), "OK");
+                await DisplayAlert("Error selecting feature", ex.ToString(), "OK");
             }
         }
 
@@ -143,7 +143,7 @@ namespace ArcGIS.Samples.EditFeatureAttachments
 
                 if (!_filename.EndsWith(".jpg") && !_filename.EndsWith(".jpeg"))
                 {
-                    await Application.Current.MainPage.DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
+                    await DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
                     return;
                 }
                 filename = _filename;
@@ -157,7 +157,7 @@ namespace ArcGIS.Samples.EditFeatureAttachments
 
                 if (!fileData.FileName.EndsWith(".jpg") && !fileData.FileName.EndsWith(".jpeg"))
                 {
-                    await Application.Current.MainPage.DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
+                    await DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
                     return;
                 }
 
@@ -185,11 +185,11 @@ namespace ArcGIS.Samples.EditFeatureAttachments
                 _selectedFeature.Refresh();
                 AttachmentsListBox.ItemsSource = await GetJpegAttachmentsAsync(_selectedFeature);
 
-                await Application.Current.MainPage.DisplayAlert("Success!", "Successfully added attachment", "OK");
+                await DisplayAlert("Success!", "Successfully added attachment", "OK");
             }
             catch (Exception exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error adding attachment", exception.Message, "OK");
+                await DisplayAlert("Error adding attachment", exception.Message, "OK");
             }
             finally
             {
@@ -223,11 +223,11 @@ namespace ArcGIS.Samples.EditFeatureAttachments
                 AttachmentsListBox.ItemsSource = await GetJpegAttachmentsAsync(_selectedFeature);
 
                 // Show success message.
-                await Application.Current.MainPage.DisplayAlert("Success!", "Successfully deleted attachment", "OK");
+                await DisplayAlert("Success!", "Successfully deleted attachment", "OK");
             }
             catch (Exception exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error deleting attachment", exception.ToString(), "OK");
+                await DisplayAlert("Error deleting attachment", exception.ToString(), "OK");
             }
             finally
             {
@@ -254,16 +254,16 @@ namespace ArcGIS.Samples.EditFeatureAttachments
                     Stream contentStream = await selectedAttachment.GetDataAsync();
                     imageView.Source = ImageSource.FromStream(() => contentStream);
                     previewPage.Content = imageView;
-                    await Application.Current.MainPage.Navigation.PushAsync(previewPage);
+                    await Navigation.PushAsync(previewPage);
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Can't show attachment", "This sample can only show image attachments.", "OK");
+                    await DisplayAlert("Can't show attachment", "This sample can only show image attachments.", "OK");
                 }
             }
             catch (Exception exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error reading attachment", exception.ToString(), "OK");
+                await DisplayAlert("Error reading attachment", exception.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
@@ -58,7 +58,7 @@ namespace ArcGIS.Samples.EditFeatureLinkedAnnotation
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -113,7 +113,7 @@ namespace ArcGIS.Samples.EditFeatureLinkedAnnotation
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -170,7 +170,7 @@ namespace ArcGIS.Samples.EditFeatureLinkedAnnotation
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -128,12 +128,12 @@ namespace ArcGIS.Samples.FeatureLayerQuery
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("State Not Found!", "Add a valid state name.", "OK");
+                    await DisplayAlert("State Not Found!", "Add a valid state name.", "OK");
                 }
             }
             catch (Exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred", "OK");
+                await DisplayAlert("Sample error", "An error occurred", "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GenerateGeodatabaseReplica/GenerateGeodatabaseReplica.xaml.cs
@@ -111,7 +111,7 @@ namespace ArcGIS.Samples.GenerateGeodatabaseReplica
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -218,7 +218,7 @@ namespace ArcGIS.Samples.GenerateGeodatabaseReplica
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
                 // Tell the user that the geodatabase was unregistered.
-                await Application.Current.MainPage.DisplayAlert("Alert", "Since no edits will be made, the local geodatabase has been unregistered per best practice.", "OK");
+                await DisplayAlert("Alert", "Since no edits will be made, the local geodatabase has been unregistered per best practice.", "OK");
 
                 // Re-enable generate button.
                 MyGenerateButton.IsEnabled = true;
@@ -241,7 +241,7 @@ namespace ArcGIS.Samples.GenerateGeodatabaseReplica
                     message += ": " + String.Join("\n", job.Messages.Select(m => m.Message));
                 }
 
-                await Application.Current.MainPage.DisplayAlert("Alert", message, "OK");
+                await DisplayAlert("Alert", message, "OK");
             }
         }
 
@@ -260,7 +260,7 @@ namespace ArcGIS.Samples.GenerateGeodatabaseReplica
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -275,7 +275,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             try
             {
                 // Ask the user if they want to commit or rollback the transaction (or cancel to keep working in the transaction).
-                string choice = await Application.Current.MainPage.DisplayActionSheet("Transaction", "Cancel", null, "Commit", "Rollback");
+                string choice = await DisplayActionSheet("Transaction", "Cancel", null, "Commit", "Rollback");
 
                 if (choice == "Commit")
                 {
@@ -299,7 +299,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -315,7 +315,7 @@ namespace ArcGIS.Samples.GeodatabaseTransactions
             // Warn the user if disabling transactions while a transaction is active.
             if (!mustHaveTransaction && _localGeodatabase.IsInTransaction)
             {
-                Application.Current.MainPage.DisplayAlert("Stop editing to end the current transaction.", "Current Transaction", "OK");
+                DisplayAlert("Stop editing to end the current transaction.", "Current Transaction", "OK");
                 RequireTransactionCheckBox.IsToggled = true;
                 return;
             }

--- a/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.ListRelatedFeatures
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -132,7 +132,7 @@ namespace ArcGIS.Samples.ListRelatedFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/ManageFeatures.xaml.cs
@@ -93,7 +93,7 @@ namespace ArcGIS.Samples.ManageFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -122,11 +122,11 @@ namespace ArcGIS.Samples.ManageFeatures
                 feature.Refresh();
 
                 // Confirm feature addition.
-                await Application.Current.MainPage.DisplayAlert("Success", $"Created feature {feature.Attributes["objectid"]}", "OK");
+                await DisplayAlert("Success", $"Created feature {feature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -163,7 +163,7 @@ namespace ArcGIS.Samples.ManageFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -179,11 +179,11 @@ namespace ArcGIS.Samples.ManageFeatures
                 await serviceTable.ServiceGeodatabase.ApplyEditsAsync();
 
                 // Show a message confirming the deletion.
-                await Application.Current.MainPage.DisplayAlert("Success", $"Deleted feature with ID {_selectedFeature.Attributes["objectid"]}", "OK");
+                await DisplayAlert("Success", $"Deleted feature with ID {_selectedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
             finally
             {
@@ -229,7 +229,7 @@ namespace ArcGIS.Samples.ManageFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -260,11 +260,11 @@ namespace ArcGIS.Samples.ManageFeatures
                 Instructions.Text = _instructions[2];
                 DamageTypePicker.IsVisible = false;
 
-                await Application.Current.MainPage.DisplayAlert("Success", $"Edited feature {_selectedFeature.Attributes["objectid"]}", "OK");
+                await DisplayAlert("Success", $"Edited feature {_selectedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
             finally
             {
@@ -312,11 +312,11 @@ namespace ArcGIS.Samples.ManageFeatures
                 // Push the update to the service with the service geodatabase.
                 var serviceTable = (ServiceFeatureTable)_selectedFeature.FeatureTable;
                 await serviceTable.ServiceGeodatabase.ApplyEditsAsync();
-                await Application.Current.MainPage.DisplayAlert("Success", $"Moved feature {_selectedFeature.Attributes["objectid"]}", "OK");
+                await DisplayAlert("Success", $"Moved feature {_selectedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
             finally
             {
@@ -406,7 +406,7 @@ namespace ArcGIS.Samples.ManageFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
                 return null;
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGIS.Samples.QueryFeaturesWithArcadeExpression
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
 
             // Load the map.
@@ -128,7 +128,7 @@ namespace ArcGIS.Samples.QueryFeaturesWithArcadeExpression
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
@@ -62,7 +62,7 @@ namespace ArcGIS.Samples.RasterLayerGeoPackage
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -75,7 +75,7 @@ namespace ArcGIS.Samples.ReadGeoPackage
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
@@ -50,7 +50,7 @@ namespace ArcGIS.Samples.ReadShapefileMetadata
                 // Read the thumbnail image data into a byte array.
                 Stream imageStream = await fileInfo.Thumbnail.GetEncodedBufferAsync();
                 byte[] imageData = new byte[imageStream.Length];
-                imageStream.Read(imageData, 0, imageData.Length);
+                imageStream.ReadExactly(imageData);
 
                 // Create a new image source from the thumbnail data.
                 ImageSource streamImageSource = ImageSource.FromStream(() => new MemoryStream(imageData));

--- a/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGIS.Samples.ReadShapefileMetadata
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
@@ -138,7 +138,7 @@ namespace ArcGIS.Samples.StatisticalQuery
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGIS.Samples.StatsQueryGroupAndSort
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.StatsQueryGroupAndSort
             // Verify that there is at least one statistic definition.
             if (!_statDefinitions.Any())
             {
-                _ = Application.Current.MainPage.DisplayAlert("Please define at least one statistic for the query.", "Statistical Query", "OK");
+                _ = DisplayAlert("Please define at least one statistic for the query.", "Statistical Query", "OK");
                 return;
             }
 
@@ -138,7 +138,7 @@ namespace ArcGIS.Samples.StatsQueryGroupAndSort
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
@@ -89,7 +89,7 @@ namespace ArcGIS.Samples.SymbolizeShapefile
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Data/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGIS.Samples.ToggleBetweenFeatureRequestModes
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -129,7 +129,7 @@ namespace ArcGIS.Samples.ToggleBetweenFeatureRequestModes
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/Buffer/Buffer.xaml.cs
@@ -118,7 +118,7 @@ namespace ArcGIS.Samples.Buffer
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem generating the buffers.
-                await Application.Current.MainPage.DisplayAlert("Error creating buffers", ex.Message, "OK");
+                await DisplayAlert("Error creating buffers", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.ConvexHull
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem adding user tapped graphics.
-                Application.Current.MainPage.DisplayAlert("Error", "Can't add user tapped graphic: " + ex.Message, "OK");
+                DisplayAlert("Error", "Can't add user tapped graphic: " + ex.Message, "OK");
             }
         }
 
@@ -134,7 +134,7 @@ namespace ArcGIS.Samples.ConvexHull
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem generating convex hull operation.
-                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error performing convex hull: " + ex.Message, "OK");
+                DisplayAlert("Geometry Engine Failed", "Error performing convex hull: " + ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
@@ -186,7 +186,7 @@ namespace ArcGIS.Samples.ConvexHullList
             catch (Exception ex)
             {
                 // Display an error message if there is a problem generating convex hull operation.
-                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error creating convex hull: " + ex.Message, "OK");
+                DisplayAlert("Geometry Engine Failed", "Error creating convex hull: " + ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -293,7 +293,7 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error editing", ex.Message, "OK");
+                await DisplayAlert("Error editing", ex.Message, "OK");
 
                 ResetFromEditingSession();
                 return;

--- a/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -95,7 +95,7 @@ namespace ArcGIS.Samples.FormatCoordinates
             catch (Exception ex)
             {
                 // The coordinate is malformed, warn and return
-                Application.Current.MainPage.DisplayAlert("Invalid Format", ex.Message, "OK");
+                DisplayAlert("Invalid Format", ex.Message, "OK");
                 return;
             }
 
@@ -112,7 +112,7 @@ namespace ArcGIS.Samples.FormatCoordinates
             }
             catch (Exception ex)
             {
-                Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                DisplayAlert("Error", ex.Message, "OK");
                 return;
             }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
@@ -95,7 +95,7 @@ namespace ArcGIS.Samples.ListTransformations
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SnapGeometryEdits/SnapGeometryEdits.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SnapGeometryEdits/SnapGeometryEdits.xaml.cs
@@ -180,7 +180,7 @@ namespace ArcGIS.Samples.SnapGeometryEdits
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error editing", ex.Message, "OK");
+                await DisplayAlert("Error editing", ex.Message, "OK");
 
                 // Reset the UI.
                 ResetFromEditingSession();

--- a/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
@@ -118,7 +118,7 @@ namespace ArcGIS.Samples.SpatialRelationships
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
 
             // Return if there are no results

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -51,7 +51,7 @@ namespace ArcGIS.Samples.AnalyzeHotspots
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -68,7 +68,7 @@ namespace ArcGIS.Samples.AnalyzeHotspots
             if (EndDate.Date <= StartDate.Date.AddDays(1))
             {
                 // Show error message
-                _ = Application.Current.MainPage.DisplayAlert("Invalid date range", "Please select valid time range. There has to be at least one day in between To and From dates.", "OK");
+                _ = DisplayAlert("Invalid date range", "Please select valid time range. There has to be at least one day in between To and From dates.", "OK");
 
                 // Remove the busy activity indication
                 MyActivityIndicator.IsRunning = false;
@@ -111,11 +111,11 @@ namespace ArcGIS.Samples.AnalyzeHotspots
                 // Display error messages if the geoprocessing task fails
                 if (_hotspotJob.Status == JobStatus.Failed && _hotspotJob.Error != null)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + _hotspotJob.Error.Message, "OK");
+                    await DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + _hotspotJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -87,7 +87,7 @@ namespace ArcGIS.Samples.AnalyzeViewshed
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -146,11 +146,11 @@ namespace ArcGIS.Samples.AnalyzeViewshed
                 // Display an error message if there is a problem.
                 if (myViewshedJob.Status == JobStatus.Failed && myViewshedJob.Error != null)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + myViewshedJob.Error.Message, "OK");
+                    await DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + myViewshedJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGIS.Samples.ListGeodatabaseVersions
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
 
             // Set the UI to indicate that the geoprocessing is not running
@@ -110,11 +110,11 @@ namespace ArcGIS.Samples.ListGeodatabaseVersions
                 // Error handling if something goes wrong
                 if (listVersionsJob.Status == JobStatus.Failed && listVersionsJob.Error != null)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + listVersionsJob.Error.Message, "OK");
+                    await DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + listVersionsJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -175,7 +175,7 @@ namespace ArcGIS.Samples.Animate3DGraphic
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGIS.Samples.DictionaryRendererGraphicsOverlay
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
@@ -102,13 +102,13 @@ namespace ArcGIS.Samples.IdentifyGraphics
                     // Make sure that the UI changes are done in the UI thread
                     Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () =>
                     {
-                        await Application.Current.MainPage.DisplayAlert("", "Tapped on graphic", "OK");
+                        await DisplayAlert("", "Tapped on graphic", "OK");
                     });
                 }
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
@@ -75,7 +75,7 @@ namespace ArcGIS.Samples.AddEncExchangeSet
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
@@ -86,7 +86,7 @@ namespace ArcGIS.Samples.ChangeEncDisplaySettings
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGIS.Samples.SelectEncFeatures
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -133,7 +133,7 @@ namespace ArcGIS.Samples.SelectEncFeatures
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddCustomDynamicEntityDataSource/SimulatedDataSource.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddCustomDynamicEntityDataSource/SimulatedDataSource.cs
@@ -16,13 +16,14 @@ using System.Text.Json;
 
 namespace ArcGIS.Samples.AddCustomDynamicEntityDataSource
 {
+#nullable enable
     public class SimulatedDataSource : DynamicEntityDataSource
     {
         // Hold a reference to the file stream reader, the process task, and the cancellation token source.
         private Task? _processTask;
         private StreamReader? _streamReader;
         private CancellationTokenSource? _cancellationTokenSource;
-        private List<Field> _fields;
+        private List<Field>? _fields;
 
         public SimulatedDataSource(string filePath, string entityIdField, TimeSpan delay)
         {
@@ -42,15 +43,18 @@ namespace ArcGIS.Samples.AddCustomDynamicEntityDataSource
 
         protected override async Task<DynamicEntityDataSourceInfo> OnLoadAsync()
         {
-            // Derive schema from the first row in the custom data source.
-            _fields = GetSchema();
+            return await Task.Run(() =>
+            {
+                // Derive schema from the first row in the custom data source.
+                _fields = GetSchema();
 
-            // Open the file for processing.
-            Stream stream = File.OpenRead(FilePath);
-            _streamReader = new StreamReader(stream);
+                // Open the file for processing.
+                Stream stream = File.OpenRead(FilePath);
+                _streamReader = new StreamReader(stream);
 
-            // Create a new DynamicEntityDataSourceInfo using the entity ID field and the fields derived from the attributes of each observation in the custom data source.
-            return new DynamicEntityDataSourceInfo(EntityIdField, _fields) { SpatialReference = SpatialReferences.Wgs84 };
+                // Create a new DynamicEntityDataSourceInfo using the entity ID field and the fields derived from the attributes of each observation in the custom data source.
+                return new DynamicEntityDataSourceInfo(EntityIdField, _fields) { SpatialReference = SpatialReferences.Wgs84 };
+            });
         }
 
         protected override Task OnConnectAsync(CancellationToken cancellationToken)
@@ -82,7 +86,7 @@ namespace ArcGIS.Samples.AddCustomDynamicEntityDataSource
                     var processed = await ProcessNextObservation();
 
                     // If the end of the file has been reached, break out of the loop.
-                    if (_streamReader.EndOfStream) break;
+                    if (_streamReader != null && _streamReader.EndOfStream) break;
 
                     // If the observation was not processed, continue to the next observation.
                     if (!processed) continue;
@@ -192,4 +196,5 @@ namespace ArcGIS.Samples.AddCustomDynamicEntityDataSource
             };
         }
     }
+#nullable disable
 }

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.xaml.cs
@@ -91,7 +91,7 @@ namespace ArcGIS.Samples.AddVectorTiledLayerFromCustomStyle
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -105,7 +105,7 @@ namespace ArcGIS.Samples.AddVectorTiledLayerFromCustomStyle
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -157,7 +157,7 @@ namespace ArcGIS.Samples.AddVectorTiledLayerFromCustomStyle
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
                 return null;
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseOAFeatureService/BrowseOAFeatureService.xaml.cs
@@ -70,7 +70,7 @@ namespace ArcGIS.Samples.BrowseOAFeatureService
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert(ex.Message, "Error loading service", "OK");
+                await DisplayAlert(ex.Message, "Error loading service", "OK");
             }
             finally
             {
@@ -124,7 +124,7 @@ namespace ArcGIS.Samples.BrowseOAFeatureService
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert(ex.Message, "Error loading service", "OK");
+                await DisplayAlert(ex.Message, "Error loading service", "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGIS.Samples.BrowseWfsLayers
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert(ex.Message, "Error loading service", "OK");
+                await DisplayAlert(ex.Message, "Error loading service", "OK");
             }
             finally
             {
@@ -131,7 +131,7 @@ namespace ArcGIS.Samples.BrowseWfsLayers
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert(ex.Message, "Error loading service", "OK");
+                await DisplayAlert(ex.Message, "Error loading service", "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.ChangeBlendRenderer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGIS.Samples.ChangeStretchRenderer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -143,7 +143,7 @@ namespace ArcGIS.Samples.ChangeStretchRenderer
             }
             catch (Exception ex)
             {
-                Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
+                DisplayAlert("Alert", ex.Message, "OK");
                 return;
             }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -98,11 +98,11 @@ namespace ArcGIS.Samples.ChangeSublayerVisibility
                 };
 
                 // Navigate to the sublayers page
-                await Application.Current.MainPage.Navigation.PushAsync(sublayersPage);
+                await Navigation.PushAsync(sublayersPage);
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
@@ -131,7 +131,7 @@ namespace ArcGIS.Samples.CreateAndSaveKmlFile
             }
             catch (ArgumentException)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "Unsupported Geometry", "OK");
+                await DisplayAlert("Error", "Unsupported Geometry", "OK");
             }
         }
 
@@ -310,7 +310,7 @@ namespace ArcGIS.Samples.CreateAndSaveKmlFile
             catch (Exception ex)
             {
                 Debug.Write(ex.Message);
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -327,7 +327,7 @@ namespace ArcGIS.Samples.CreateAndSaveKmlFile
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
@@ -115,7 +115,7 @@ namespace ArcGIS.Samples.CreateFeatureCollectionLayer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayDimensions/DisplayDimensions.xaml.cs
@@ -59,7 +59,7 @@ namespace ArcGIS.Samples.DisplayDimensions
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.xaml.cs
@@ -87,7 +87,7 @@ namespace ArcGIS.Samples.DisplayFeatureLayers
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGIS.Samples.DisplayKml
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
@@ -56,7 +56,7 @@ namespace ArcGIS.Samples.DisplayKmlNetworkLinks
             // The dispatcher takes an Action, provided here as a lambda function.
             Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () =>
             {
-                await Application.Current.MainPage.DisplayAlert("KML layer message", e.Message, "OK");
+                await DisplayAlert("KML layer message", e.Message, "OK");
             });
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayOACollection/DisplayOACollection.xaml.cs
@@ -77,7 +77,7 @@ namespace ArcGIS.Samples.DisplayOACollection
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -106,7 +106,7 @@ namespace ArcGIS.Samples.DisplayOACollection
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Couldn't populate table.", ex.Message, "OK");
+                await DisplayAlert("Couldn't populate table.", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayRouteLayer/DisplayRouteLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayRouteLayer/DisplayRouteLayer.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGIS.Samples.DisplayRouteLayer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -121,7 +121,7 @@ namespace ArcGIS.Samples.DisplaySubtypeFeatureLayer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
@@ -76,7 +76,7 @@ namespace ArcGIS.Samples.DisplayWfs
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "Couldn't load sample.");
+                await DisplayAlert("Error", e.ToString(), "Couldn't load sample.");
                 Debug.WriteLine(e);
             }
         }
@@ -102,7 +102,7 @@ namespace ArcGIS.Samples.DisplayWfs
             }
             catch (Exception exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", exception.ToString(), "Couldn't populate table.");
+                await DisplayAlert("Error", exception.ToString(), "Couldn't populate table.");
                 Debug.WriteLine(exception);
             }
             finally

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -102,7 +102,7 @@ namespace ArcGIS.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -199,7 +199,7 @@ namespace ArcGIS.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -266,7 +266,7 @@ namespace ArcGIS.Samples.ExportTiles
             else if (_job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
                 // Notify the user.
-                await Application.Current.MainPage.DisplayAlert("Error", "Job Failed", "OK");
+                await DisplayAlert("Error", "Job Failed", "OK");
 
                 // Update the UI.
                 MyExportPreviewButton.Text = "Export Tiles";
@@ -335,7 +335,7 @@ namespace ArcGIS.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ExportVectorTiles/ExportVectorTiles.xaml.cs
@@ -155,7 +155,7 @@ namespace ArcGIS.Samples.ExportVectorTiles
             else if (_job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
                 // Notify the user.
-                await Application.Current.MainPage.DisplayAlert("Error", "Job failed", "OK");
+                await DisplayAlert("Error", "Job failed", "OK");
 
                 // Update the UI.
                 MyExportPreviewButton.Text = "Export Tiles";
@@ -272,7 +272,7 @@ namespace ArcGIS.Samples.ExportVectorTiles
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
@@ -66,12 +66,12 @@ namespace ArcGIS.Samples.FeatureCollectionLayerFromPortal
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Feature Collection", "Portal item with ID '" + itemId + "' is not a feature collection.", "OK");
+                    await DisplayAlert("Feature Collection", "Portal item with ID '" + itemId + "' is not a feature collection.", "OK");
                 }
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "Unable to open item with ID '" + itemId + "': " + ex.Message, "OK");
+                await DisplayAlert("Error", "Unable to open item with ID '" + itemId + "': " + ex.Message, "OK");
             }
         }
 
@@ -83,7 +83,7 @@ namespace ArcGIS.Samples.FeatureCollectionLayerFromPortal
             // Make sure an Id was entered.
             if (String.IsNullOrEmpty(collectionItemId))
             {
-                _ = Application.Current.MainPage.DisplayAlert("Feature Collection ID", "Please enter a portal item ID", "OK");
+                _ = DisplayAlert("Feature Collection ID", "Please enter a portal item ID", "OK");
                 return;
             }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
@@ -70,7 +70,7 @@ namespace ArcGIS.Samples.FeatureCollectionLayerFromQuery
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
@@ -100,7 +100,7 @@ namespace ArcGIS.Samples.FeatureLayerDefinitionExpression
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGIS.Samples.FeatureLayerDictionaryRenderer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.FeatureLayerRenderingModeMap
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGIS.Samples.FeatureLayerSelection
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -121,7 +121,7 @@ namespace ArcGIS.Samples.FeatureLayerSelection
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/GroupLayers/GroupLayers.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGIS.Samples.GroupLayers
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
 
             // Add rows for any children of this layer if it is a group layer.

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
@@ -80,11 +80,11 @@ namespace ArcGIS.Samples.IdentifyKmlFeatures
                 }
 
                 // Show a page with the HTML content
-                await Application.Current.MainPage.Navigation.PushAsync(new KmlIdentifyResultDisplayPage(firstIdentifiedPlacemark.BalloonContent));
+                await Navigation.PushAsync(new KmlIdentifyResultDisplayPage(firstIdentifiedPlacemark.BalloonContent));
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.IdentifyRasterCell
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
 
             // Listen for mouse movement to start the identify operation.
@@ -118,7 +118,7 @@ namespace ArcGIS.Samples.IdentifyRasterCell
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
@@ -67,7 +67,7 @@ namespace ArcGIS.Samples.ListKmlContents
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -101,7 +101,7 @@ namespace ArcGIS.Samples.ListKmlContents
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGIS.Samples.MapImageLayerTables
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -125,7 +125,7 @@ namespace ArcGIS.Samples.MapImageLayerTables
                 ArcGISFeature serviceRequestFeature = result.FirstOrDefault() as ArcGISFeature;
                 if (serviceRequestFeature == null)
                 {
-                    await Application.Current.MainPage.DisplayAlert("No Feature", "Related feature not found.", "OK");
+                    await DisplayAlert("No Feature", "Related feature not found.", "OK");
                     return;
                 }
 
@@ -147,7 +147,7 @@ namespace ArcGIS.Samples.MapImageLayerTables
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
@@ -136,7 +136,7 @@ namespace ArcGIS.Samples.MapImageSublayerQuery
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -86,7 +86,7 @@ namespace ArcGIS.Samples.PlayKmlTours
             catch (Exception e)
             {
                 Debug.WriteLine(e.ToString());
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml.cs
@@ -100,7 +100,7 @@ namespace ArcGIS.Samples.QueryCQLFilters
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {
@@ -164,7 +164,7 @@ namespace ArcGIS.Samples.QueryCQLFilters
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/RasterColormapRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterColormapRenderer/RasterColormapRenderer.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGIS.Samples.RasterColormapRenderer
             catch (Exception e)
             {
                 Debug.WriteLine(e.Message);
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.RasterHillshade
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -60,7 +60,7 @@ namespace ArcGIS.Samples.RasterLayerFile
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
@@ -114,7 +114,7 @@ namespace ArcGIS.Samples.RasterLayerRasterFunction
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
@@ -86,7 +86,7 @@ namespace ArcGIS.Samples.RasterRenderingRule
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -95,7 +95,7 @@ namespace ArcGIS.Samples.RasterRenderingRule
             try
             {
                 // Display a picker to the user to choose among the available rendering rules for the image service raster
-                string myRenderingRuleInfoName = await Application.Current.MainPage.DisplayActionSheet("Select a Rendering Rule", "Cancel", null, _names.ToArray());
+                string myRenderingRuleInfoName = await DisplayActionSheet("Select a Rendering Rule", "Cancel", null, _names.ToArray());
 
                 // Loop through each rendering rule info in the image service raster
                 foreach (RenderingRuleInfo myRenderingRuleInfo in _myReadOnlyListRenderRuleInfos)
@@ -126,7 +126,7 @@ namespace ArcGIS.Samples.RasterRenderingRule
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
@@ -101,7 +101,7 @@ namespace ArcGIS.Samples.RasterRgbRenderer
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGIS.Samples.SceneLayerSelection
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -90,7 +90,7 @@ namespace ArcGIS.Samples.SceneLayerSelection
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGIS.Samples.SceneLayerUrl
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -73,7 +73,7 @@ namespace ArcGIS.Samples.ShowLabelsOnLayer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGIS.Samples.StyleWmsLayer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
@@ -86,7 +86,7 @@ namespace ArcGIS.Samples.TimeBasedQuery
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
@@ -96,7 +96,7 @@ namespace ArcGIS.Samples.WMTSLayer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Sample error", ex.ToString(), "OK");
+                await DisplayAlert("Sample error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGIS.Samples.WfsXmlQuery
             catch (Exception e)
             {
                 Debug.WriteLine(e.ToString());
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "Couldn't populate table with XML query.");
+                await DisplayAlert("Error", e.ToString(), "Couldn't populate table with XML query.");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGIS.Samples.WmsIdentify
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -101,11 +101,11 @@ namespace ArcGIS.Samples.WmsIdentify
                 }
 
                 // Show a page with the HTML content
-                await Application.Current.MainPage.Navigation.PushAsync(new WmsIdentifyResultDisplayPage(htmlContent));
+                await Navigation.PushAsync(new WmsIdentifyResultDisplayPage(htmlContent));
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGIS.Samples.WmsServiceCatalog
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -107,7 +107,7 @@ namespace ArcGIS.Samples.WmsServiceCatalog
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -111,7 +111,7 @@ namespace ArcGIS.Samples.DisplayDeviceLocation
                 // Note for MacCatalyst: while on ethernet, without an external GPS device connected,
                 // location will be unknown.
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -155,7 +155,7 @@ namespace ArcGIS.Samples.IndoorPositioning
             get
             {
                 // Devices running Android 12 or higher need the `BluetoothScan` permission. Android 11 and below require the `Bluetooth` and `BluetoothAdmin` permissions.
-                if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.S)
+                if (OperatingSystem.IsAndroidVersionAtLeast(31))
                 {
                     return new List<(string androidPermission, bool isRuntime)>
                     {

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.IndoorPositioning
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml
@@ -14,13 +14,12 @@
                         Text="Pause" />
             </StackLayout>
         </Border>
-        <Frame x:Name="PopupPage"
+        <Border x:Name="PopupPage"
                Grid.RowSpan="4"
                Grid.ColumnSpan="4"
                Padding="0"
                BackgroundColor="{AppThemeBinding Light=#dfdfdf,
                                                  Dark=#303030}"
-               CornerRadius="0"
                IsVisible="False">
             <ScrollView>
                 <StackLayout>
@@ -37,6 +36,6 @@
                             Text="Close" />
                 </StackLayout>
             </ScrollView>
-        </Frame>
+        </Border>
     </Grid>
 </ContentPage>

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationDrivenGeotriggers/LocationDrivenGeotriggers.xaml.cs
@@ -87,7 +87,7 @@ namespace ArcGIS.Samples.LocationDrivenGeotriggers
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.Message.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.Message.GetType().Name, ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -175,7 +175,7 @@ namespace ArcGIS.Samples.ShowLocationHistory
 
         private async Task ShowMessage(string title, string detail)
         {
-            await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
+            await DisplayAlert(title, detail, "OK");
         }
 
         public void Dispose()

--- a/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ApplyScheduledUpdates/ApplyScheduledUpdates.xaml.cs
@@ -82,7 +82,7 @@ namespace ArcGIS.Samples.ApplyScheduledUpdates
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -112,7 +112,7 @@ namespace ArcGIS.Samples.ApplyScheduledUpdates
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -161,7 +161,7 @@ namespace ArcGIS.Samples.ApplyScheduledUpdates
                         }
                         else
                         {
-                            await Application.Current.MainPage.DisplayAlert("Error", "Failed to load the mobile map package.", "OK");
+                            await DisplayAlert("Error", "Failed to load the mobile map package.", "OK");
                         }
                     }
 
@@ -170,12 +170,12 @@ namespace ArcGIS.Samples.ApplyScheduledUpdates
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "Error syncing the offline map.", "OK");
+                    await DisplayAlert("Error", "Error syncing the offline map.", "OK");
                 }
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.AuthorMap
             mapInputForm.OnSaveClicked += SaveMapAsync;
 
             // Navigate to the SaveMapPage UI.
-            Application.Current.MainPage.Navigation.PushAsync(mapInputForm);
+            Navigation.PushAsync(mapInputForm);
         }
 
         // Event handler to get information entered by the user and save the map.
@@ -121,7 +121,7 @@ namespace ArcGIS.Samples.AuthorMap
                     await myMap.SaveAsAsync(agsOnline, null, title, description, tags, thumbnailImage);
 
                     // Report a successful save.
-                    await Application.Current.MainPage.DisplayAlert("Map Saved", "Saved '" + title + "' to ArcGIS Online!", "OK");
+                    await DisplayAlert("Map Saved", "Saved '" + title + "' to ArcGIS Online!", "OK");
                 }
                 else
                 {
@@ -136,13 +136,13 @@ namespace ArcGIS.Samples.AuthorMap
                     await myMap.SaveAsync();
 
                     // Report update was successful.
-                    await Application.Current.MainPage.DisplayAlert("Updates Saved", "Saved changes to '" + myMap.Item.Title + "'", "OK");
+                    await DisplayAlert("Updates Saved", "Saved changes to '" + myMap.Item.Title + "'", "OK");
                 }
             }
             catch (Exception ex)
             {
                 // Show the exception message.
-                await Application.Current.MainPage.DisplayAlert("Unable to save map", ex.Message, "OK");
+                await DisplayAlert("Unable to save map", ex.Message, "OK");
             }
             finally
             {
@@ -162,7 +162,7 @@ namespace ArcGIS.Samples.AuthorMap
         {
             try
             {
-                string selectionName = await Application.Current.MainPage.DisplayActionSheet("Select basemap", "Cancel", null, _basemaps.Keys.ToArray());
+                string selectionName = await DisplayActionSheet("Select basemap", "Cancel", null, _basemaps.Keys.ToArray());
 
                 if (selectionName == "Cancel") return;
 
@@ -181,7 +181,7 @@ namespace ArcGIS.Samples.AuthorMap
             {
                 string[] inMapNames = MyMapView.Map.OperationalLayers.Select(l => l.Name).ToArray();
                 string[] optionNames = _operationalLayerUrls.Where(l => !inMapNames.Contains(l.Key)).Select(l => l.Key).ToArray();
-                string selectionName = await Application.Current.MainPage.DisplayActionSheet("Select layer to add", "Cancel", null, optionNames);
+                string selectionName = await DisplayActionSheet("Select layer to add", "Cancel", null, optionNames);
 
                 if (selectionName == "Cancel") return;
 
@@ -204,7 +204,7 @@ namespace ArcGIS.Samples.AuthorMap
         {
             try
             {
-                string selectionName = await Application.Current.MainPage.DisplayActionSheet("Select layer to remove", "Cancel", null, MyMapView.Map.OperationalLayers.Select(l => l.Name).ToArray());
+                string selectionName = await DisplayActionSheet("Select layer to remove", "Cancel", null, MyMapView.Map.OperationalLayers.Select(l => l.Name).ToArray());
 
                 if (selectionName == "Cancel") return;
 

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/SaveMapPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/SaveMapPage.xaml.cs
@@ -52,19 +52,19 @@ namespace ArcGIS.Samples.AuthorMap
                 OnSaveClicked?.Invoke(this, mapSavedArgs);
 
                 // Close the dialog
-                Application.Current.MainPage.Navigation.PopAsync();
+                Navigation.PopAsync();
             }
             catch (Exception ex)
             {
                 // Show the exception message (dialog will stay open so user can try again)
-                Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
         private void CancelButtonClicked(object sender, EventArgs e)
         {
             // If the user cancels, just navigate back to the previous page
-            Application.Current.MainPage.Navigation.PopAsync();
+            Navigation.PopAsync();
         }
     }
 

--- a/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/BrowseBuildingFloors/BrowseBuildingFloors.xaml.cs
@@ -47,7 +47,7 @@ namespace ArcGIS.Samples.BrowseBuildingFloors
                 // Checks to see if the layer is floor aware.
                 if (MyMapView.Map.FloorDefinition == null)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Alert", "The layer is not floor aware.", "OK");
+                    await DisplayAlert("Alert", "The layer is not floor aware.", "OK");
                     return;
                 }
 
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.BrowseBuildingFloors
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
+                await DisplayAlert("Alert", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
@@ -94,7 +94,7 @@ namespace ArcGIS.Samples.DownloadPreplannedMap
             {
                 // Something unexpected happened, show the error message.
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert("There was an error.", ex.Message, "OK");
+                await DisplayAlert("There was an error.", ex.Message, "OK");
             }
         }
 
@@ -140,7 +140,7 @@ namespace ArcGIS.Samples.DownloadPreplannedMap
                 catch (Exception e)
                 {
                     Debug.WriteLine(e);
-                    await Application.Current.MainPage.DisplayAlert("Couldn't open offline area. Proceeding to take area offline.", e.Message, "OK");
+                    await DisplayAlert("Couldn't open offline area. Proceeding to take area offline.", e.Message, "OK");
                 }
             }
 
@@ -181,7 +181,7 @@ namespace ArcGIS.Samples.DownloadPreplannedMap
                     }
 
                     // Show the message.
-                    await Application.Current.MainPage.DisplayAlert("Warning!", errors, "OK");
+                    await DisplayAlert("Warning!", errors, "OK");
                 }
 
                 // Show the downloaded map.
@@ -196,7 +196,7 @@ namespace ArcGIS.Samples.DownloadPreplannedMap
             {
                 // Report any errors.
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert("Downloading map area failed.", ex.Message, "OK");
+                await DisplayAlert("Downloading map area failed.", ex.Message, "OK");
             }
             finally
             {
@@ -253,7 +253,7 @@ namespace ArcGIS.Samples.DownloadPreplannedMap
             catch (Exception ex)
             {
                 // Report the error.
-                await Application.Current.MainPage.DisplayAlert("Deleting map areas failed.", ex.Message, "OK");
+                await DisplayAlert("Deleting map areas failed.", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
@@ -81,7 +81,7 @@ namespace ArcGIS.Samples.GenerateOfflineMap
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                await DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -140,7 +140,7 @@ namespace ArcGIS.Samples.GenerateOfflineMap
                 // Check for job failure (writing the output was denied, e.g.).
                 if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                    await DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                     busyIndicator.IsVisible = false;
                 }
 
@@ -156,7 +156,7 @@ namespace ArcGIS.Samples.GenerateOfflineMap
 
                     // Show layer errors.
                     string errorText = errorBuilder.ToString();
-                    await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
+                    await DisplayAlert("Alert", errorText, "OK");
                 }
 
                 // Display the offline map.
@@ -177,12 +177,12 @@ namespace ArcGIS.Samples.GenerateOfflineMap
             catch (TaskCanceledException)
             {
                 // Generate offline map task was canceled.
-                await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled", "OK");
+                await DisplayAlert("Alert", "Taking map offline was canceled", "OK");
             }
             catch (Exception ex)
             {
                 // Exception while taking the map offline.
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
+                await DisplayAlert("Alert", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
@@ -88,7 +88,7 @@ namespace ArcGIS.Samples.GenerateOfflineMapWithOverrides
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                await DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -158,7 +158,7 @@ namespace ArcGIS.Samples.GenerateOfflineMapWithOverrides
                         // Check for job failure (writing the output was denied, e.g.).
                         if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                         {
-                            await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                            await DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                             BusyIndicator.IsVisible = false;
                         }
 
@@ -174,7 +174,7 @@ namespace ArcGIS.Samples.GenerateOfflineMapWithOverrides
 
                             // Show layer errors.
                             string errorText = errorBuilder.ToString();
-                            await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
+                            await DisplayAlert("Alert", errorText, "OK");
                         }
 
                         // Display the offline map.
@@ -187,19 +187,19 @@ namespace ArcGIS.Samples.GenerateOfflineMapWithOverrides
                         MyMapView.InteractionOptions.IsEnabled = true;
 
                         // Show a message that the map is offline.
-                        await Application.Current.MainPage.DisplayAlert("Alert", "Map is offline.", "OK");
+                        await DisplayAlert("Alert", "Map is offline.", "OK");
 
                         TakeMapOfflineButton.IsEnabled = false;
                     }
                     catch (TaskCanceledException)
                     {
                         // Generate offline map task was canceled.
-                        await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled.", "OK");
+                        await DisplayAlert("Alert", "Taking map offline was canceled.", "OK");
                     }
                     catch (Exception ex)
                     {
                         // Exception while taking the map offline.
-                        await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                        await DisplayAlert("Alert", ex.ToString(), "OK");
                     }
                     finally
                     {
@@ -213,7 +213,7 @@ namespace ArcGIS.Samples.GenerateOfflineMapWithOverrides
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                await DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.xaml.cs
@@ -63,7 +63,7 @@ namespace ArcGIS.Samples.HonorMobileMapPackageExpiration
                     }
                     else if (expiration.Type == ExpirationType.PreventExpiredAccess)
                     {
-                        await Application.Current.MainPage.DisplayAlert("Error", "The author of this mobile map package has disallowed access after the expiration date.", "OK");
+                        await DisplayAlert("Error", "The author of this mobile map package has disallowed access after the expiration date.", "OK");
                     }
                 }
                 else if (mobileMapPackage.Maps.Any())
@@ -73,7 +73,7 @@ namespace ArcGIS.Samples.HonorMobileMapPackageExpiration
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "Failed to load the mobile map package.", "OK");
+                    await DisplayAlert("Error", "Failed to load the mobile map package.", "OK");
                 }
             }
             catch (Exception e)

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
@@ -94,7 +94,7 @@ namespace ArcGIS.Samples.ManageBookmarks
             try
             {
                 // Prompt the user for the new bookmark name.
-                string name = await Application.Current.MainPage.DisplayPromptAsync("New bookmark", "Enter name for new bookmark");
+                string name = await DisplayPromptAsync("New bookmark", "Enter name for new bookmark");
 
                 // Exit if the name is empty
                 if (string.IsNullOrEmpty(name))

--- a/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
@@ -113,7 +113,7 @@ namespace ArcGIS.Samples.MobileMapSearchAndRoute
             catch (Exception exception)
             {
                 Console.WriteLine(exception);
-                await Application.Current.MainPage.DisplayAlert("Error", "Couldn't geocode or route.", "OK");
+                await DisplayAlert("Error", "Couldn't geocode or route.", "OK");
             }
         }
 
@@ -211,7 +211,7 @@ namespace ArcGIS.Samples.MobileMapSearchAndRoute
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
@@ -70,7 +70,7 @@ namespace ArcGIS.Samples.OfflineBasemapByReference
             }
 
             // Wait for the user to choose whether to use the offline basemap.
-            bool useBasemap = await Application.Current.MainPage.DisplayAlert("Basemap choice", "Use the offline basemap?", "Yes", "No");
+            bool useBasemap = await DisplayAlert("Basemap choice", "Use the offline basemap?", "Yes", "No");
 
             if (useBasemap)
             {
@@ -122,7 +122,7 @@ namespace ArcGIS.Samples.OfflineBasemapByReference
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
+                await DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -184,7 +184,7 @@ namespace ArcGIS.Samples.OfflineBasemapByReference
                 // Check for job failure (writing the output was denied, e.g.).
                 if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                    await DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                     BusyIndicator.IsVisible = false;
                 }
 
@@ -200,7 +200,7 @@ namespace ArcGIS.Samples.OfflineBasemapByReference
 
                     // Show layer errors.
                     string errorText = errorBuilder.ToString();
-                    await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
+                    await DisplayAlert("Alert", errorText, "OK");
                 }
 
                 // Display the offline map.
@@ -216,17 +216,17 @@ namespace ArcGIS.Samples.OfflineBasemapByReference
                 TakeMapOfflineButton.IsEnabled = false;
 
                 // Show a message that the map is offline.
-                await Application.Current.MainPage.DisplayAlert("Alert", "Map is offline.", "OK");
+                await DisplayAlert("Alert", "Map is offline.", "OK");
             }
             catch (TaskCanceledException)
             {
                 // Generate offline map task was canceled.
-                await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled", "OK");
+                await DisplayAlert("Alert", "Taking map offline was canceled", "OK");
             }
             catch (Exception ex)
             {
                 // Exception while taking the map offline.
-                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
+                await DisplayAlert("Alert", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -48,7 +48,7 @@ namespace ArcGIS.Samples.OpenMapURL
             try
             {
                 // Show sheet and get title from the selection
-                string selectedMapTitle = await Application.Current.MainPage.DisplayActionSheet("Select map", "Cancel", null, _titles);
+                string selectedMapTitle = await DisplayActionSheet("Select map", "Cancel", null, _titles);
 
                 // If selected cancel do nothing
                 if (selectedMapTitle == null || selectedMapTitle == "Cancel") return;
@@ -61,7 +61,7 @@ namespace ArcGIS.Samples.OpenMapURL
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
@@ -45,7 +45,7 @@ namespace ArcGIS.Samples.OpenMobileMap
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
@@ -75,7 +75,7 @@ namespace ArcGIS.Samples.SearchPortalMaps
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -116,7 +116,7 @@ namespace ArcGIS.Samples.SearchPortalMaps
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -148,7 +148,7 @@ namespace ArcGIS.Samples.SearchPortalMaps
                 Exception err = map.LoadError;
                 if (err != null)
                 {
-                    Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() => Application.Current.MainPage.DisplayAlert(err.Message, "Map Load Error", "OK"));
+                    Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() => DisplayAlert(err.Message, "Map Load Error", "OK"));
                 }
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
@@ -76,7 +76,7 @@ namespace ArcGIS.Samples.ChangeViewpoint
             {
                 // Show sheet and get title from the selection
                 string selectedMapTitle =
-                    await Application.Current.MainPage.DisplayActionSheet("Select viewpoint", "Cancel", null, titles);
+                    await DisplayActionSheet("Select viewpoint", "Cancel", null, titles);
 
                 // If selected cancel do nothing
                 if (selectedMapTitle == "Cancel") return;
@@ -117,7 +117,7 @@ namespace ArcGIS.Samples.ChangeViewpoint
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGIS.Samples.FeatureLayerTimeOffset
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
@@ -53,7 +53,7 @@ namespace ArcGIS.Samples.IdentifyLayers
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -74,12 +74,12 @@ namespace ArcGIS.Samples.IdentifyLayers
 
                 if (!String.IsNullOrEmpty(result))
                 {
-                    await Application.Current.MainPage.DisplayAlert("Identify result", result, "OK");
+                    await DisplayAlert("Identify result", result, "OK");
                 }
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
@@ -47,7 +47,7 @@ namespace ArcGIS.Samples.TakeScreenshot
                 // Create image bitmap by getting stream from the exported image.
                 var buffer = await exportedImage.GetEncodedBufferAsync();
                 byte[] data = new byte[buffer.Length];
-                buffer.Read(data, 0, data.Length);
+                buffer.ReadExactly(data);
                 var bitmap = ImageSource.FromStream(() => new MemoryStream(data));
 
                 // Add elements into the layout.

--- a/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGIS.Samples.TakeScreenshot
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/ClosestFacility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacility/ClosestFacility.xaml.cs
@@ -115,7 +115,7 @@ namespace ArcGIS.Samples.ClosestFacility
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -169,11 +169,11 @@ namespace ArcGIS.Samples.ClosestFacility
             {
                 if (exception.Message.Equals("Unable to complete operation."))
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "Incident not within San Diego area!", "OK");
+                    await DisplayAlert("Error", "Incident not within San Diego area!", "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
+                    await DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
                 }
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
@@ -130,7 +130,7 @@ namespace ArcGIS.Samples.ClosestFacilityStatic
             }
             catch (Exception exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "An exception has occurred.\n" + exception.Message, "OK");
+                await DisplayAlert("Error", "An exception has occurred.\n" + exception.Message, "OK");
             }
         }
 
@@ -189,7 +189,7 @@ namespace ArcGIS.Samples.ClosestFacilityStatic
             }
             catch (Esri.ArcGISRuntime.Http.ArcGISWebException exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred.\n" + exception.Message, "OK");
+                await DisplayAlert("Error", "An ArcGIS web exception occurred.\n" + exception.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml.cs
@@ -135,7 +135,7 @@ namespace ArcGIS.Samples.FindRoute
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceArea/FindServiceArea.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGIS.Samples.FindServiceArea
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error", "Error drawing facility:\n" + ex.Message, "OK");
+                await DisplayAlert("Error", "Error drawing facility:\n" + ex.Message, "OK");
             }
         }
 
@@ -136,7 +136,7 @@ namespace ArcGIS.Samples.FindServiceArea
             catch (Exception ex)
             {
                 // Report exceptions.
-                await Application.Current.MainPage.DisplayAlert("Error", "Error drawing barrier:\n" + ex.Message, "OK");
+                await DisplayAlert("Error", "Error drawing barrier:\n" + ex.Message, "OK");
             }
         }
 
@@ -182,7 +182,7 @@ namespace ArcGIS.Samples.FindServiceArea
             // Check that there is at least 1 facility to find a service area for.
             if (!serviceAreaFacilities.Any())
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "Must have at least one Facility!", "OK");
+                await DisplayAlert("Error", "Must have at least one Facility!", "OK");
                 return;
             }
 
@@ -257,11 +257,11 @@ namespace ArcGIS.Samples.FindServiceArea
             {
                 if (exception.Message.ToString().Equals("Unable to complete operation."))
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "Facility not within San Diego area!", "OK");
+                    await DisplayAlert("Error", "Facility not within San Diego area!", "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
+                    await DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
                 }
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
@@ -180,7 +180,7 @@ namespace ArcGIS.Samples.FindServiceAreasForMultipleFacilities
 
         private void ShowMessage(string title, string detail)
         {
-            Application.Current.MainPage.DisplayAlert(title, detail, "OK");
+            DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
@@ -120,7 +120,7 @@ namespace ArcGIS.Samples.NavigateRoute
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRouteRerouting/NavigateRouteRerouting.xaml.cs
@@ -122,7 +122,7 @@ namespace ArcGIS.Samples.NavigateRouteRerouting
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
 
@@ -155,7 +155,7 @@ namespace ArcGIS.Samples.NavigateRouteRerouting
                 }
                 catch (Exception ex)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                    await DisplayAlert("Error", ex.Message, "OK");
                 }
             }
 

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -259,7 +259,7 @@ namespace ArcGIS.Samples.OfflineRouting
 
         private void ShowMessage(string title, string detail)
         {
-            Application.Current.MainPage.DisplayAlert(title, detail, "OK");
+            DisplayAlert(title, detail, "OK");
         }
 
         private void TravelModesCollection_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -307,7 +307,7 @@ namespace ArcGIS.Samples.RouteAroundBarriers
 
         private async Task ShowDirectionsTask()
         {
-            await Application.Current.MainPage.Navigation.PushAsync(_directionsPage);
+            await Navigation.PushAsync(_directionsPage);
         }
 
         private async Task<PictureMarkerSymbol> GetPictureMarker()
@@ -386,7 +386,7 @@ namespace ArcGIS.Samples.RouteAroundBarriers
 
         private void ShowMessage(string title, string detail)
         {
-            Application.Current.MainPage.DisplayAlert(title, detail, "OK");
+            DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
@@ -118,7 +118,7 @@ namespace ArcGIS.Samples.GetElevationAtPoint
             catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message);
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGIS.Samples.OpenMobileScenePackage
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Couldn't open scene", e.Message, "OK");
+                await DisplayAlert("Couldn't open scene", e.Message, "OK");
                 Debug.WriteLine(e);
             }
         }

--- a/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/OpenScenePortalItem.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/OpenScenePortalItem/OpenScenePortalItem.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGIS.Samples.OpenScenePortalItem
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/ShowLabelsOnLayer3D.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Scene/ShowLabelsOnLayer3D/ShowLabelsOnLayer3D.xaml.cs
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.ShowLabelsOnLayer3D
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.Message, "OK");
+                await DisplayAlert("Error", e.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -49,7 +49,7 @@ namespace ArcGIS.Samples.AnimateImageOverlay
             // This sample is only supported in x64 on .NET MAUI.
             if (!Environment.Is64BitProcess)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "This sample is only supported for .NET MAUI in x64. Run the sample viewer in x64 to use this sample.", "Exit");
+                await DisplayAlert("Error", "This sample is only supported for .NET MAUI in x64. Run the sample viewer in x64 to use this sample.", "Exit");
                 return;
             }
 

--- a/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.ChooseCameraController
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine(ex.Message);
-                await Application.Current.MainPage.DisplayAlert("Error", "Loading plane model failed. Sample failed to initialize.", "OK");
+                await DisplayAlert("Error", "Loading plane model failed. Sample failed to initialize.", "OK");
                 return;
             }
 
@@ -135,7 +135,7 @@ namespace ArcGIS.Samples.ChooseCameraController
             {
                 // Show sheet and get the camera controller from the selection.
                 string selectedCamera =
-                    await Application.Current.MainPage.DisplayActionSheet("Select camera controller", "Cancel", null, _controllers);
+                    await DisplayActionSheet("Select camera controller", "Cancel", null, _controllers);
 
                 // If selected cancel then do nothing.
                 if (selectedCamera == "Cancel") return;
@@ -145,7 +145,7 @@ namespace ArcGIS.Samples.ChooseCameraController
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindAddress/FindAddress.xaml.cs
@@ -70,7 +70,7 @@ namespace ArcGIS.Samples.FindAddress
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -119,7 +119,7 @@ namespace ArcGIS.Samples.FindAddress
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -152,7 +152,7 @@ namespace ArcGIS.Samples.FindAddress
             try
             {
                 // Display the list of suggestions; returns the selected option
-                string action = await Application.Current.MainPage.DisplayActionSheet("Choose an address to geocode", "Cancel", null, _addresses);
+                string action = await DisplayActionSheet("Choose an address to geocode", "Cancel", null, _addresses);
 
                 if (action == "Cancel")
                 {
@@ -165,7 +165,7 @@ namespace ArcGIS.Samples.FindAddress
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -200,7 +200,7 @@ namespace ArcGIS.Samples.FindAddress
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -77,7 +77,7 @@ namespace ArcGIS.Samples.FindPlace
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert("Couldn't start location", ex.Message, "OK");
+                await DisplayAlert("Couldn't start location", ex.Message, "OK");
             }
                 
 
@@ -209,7 +209,7 @@ namespace ArcGIS.Samples.FindPlace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -264,14 +264,14 @@ namespace ArcGIS.Samples.FindPlace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
         private void ShowStatusMessage(string message)
         {
             // Display the message to the user.
-            Application.Current.MainPage.DisplayAlert("Alert", message, "OK");
+            DisplayAlert("Alert", message, "OK");
         }
 
         private void MyLocationBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
@@ -78,7 +78,7 @@ namespace ArcGIS.Samples.OfflineGeocode
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -110,7 +110,7 @@ namespace ArcGIS.Samples.OfflineGeocode
                 // Stop if there are no suggestions.
                 if (!geocodeResults.Any())
                 {
-                    await Application.Current.MainPage.DisplayAlert("No results", "No results found.", "OK");
+                    await DisplayAlert("No results", "No results found.", "OK");
                     return;
                 }
 
@@ -133,7 +133,7 @@ namespace ArcGIS.Samples.OfflineGeocode
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -163,14 +163,14 @@ namespace ArcGIS.Samples.OfflineGeocode
             try
             {
                 // Display the list of suggestions; returns the selected option
-                string action = await Application.Current.MainPage.DisplayActionSheet("Choose an address to geocode", "Cancel", null, _addresses);
+                string action = await DisplayActionSheet("Choose an address to geocode", "Cancel", null, _addresses);
                 // Update the search
                 MySearchBar.Text = action;
                 _ = UpdateSearchAsync();
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -195,7 +195,7 @@ namespace ArcGIS.Samples.OfflineGeocode
                 // Skip if there are no results.
                 if (!addresses.Any())
                 {
-                    await Application.Current.MainPage.DisplayAlert("No results", "No results found.", "OK");
+                    await DisplayAlert("No results", "No results found.", "OK");
                     return;
                 }
 
@@ -214,7 +214,7 @@ namespace ArcGIS.Samples.OfflineGeocode
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
@@ -58,7 +58,7 @@ namespace ArcGIS.Samples.ReverseGeocode
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
 
             // Set the initial viewpoint.
@@ -103,7 +103,7 @@ namespace ArcGIS.Samples.ReverseGeocode
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await Application.Current.MainPage.DisplayAlert("No results", "No results found", "OK");
+                await DisplayAlert("No results", "No results found", "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/OAuth/OAuth.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGIS.Samples.OAuth
             }
             catch (Exception e)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
@@ -31,7 +31,7 @@
             // Make sure the user entered all values.
             if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             {
-                Application.Current.MainPage.DisplayAlert("Login", "Please enter a username and password", "OK");
+                DisplayAlert("Login", "Please enter a username and password", "OK");
                 return;
             }
 

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -97,7 +97,7 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
 
             // Show the login controls on the UI thread.
             // OnLoginInfoEntered event will return the values entered (username and password).
-            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () => await Application.Current.MainPage.Navigation.PushAsync(_loginPage));
+            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () => await Navigation.PushAsync(_loginPage));
 
             // Return the login task, the result will be ready when completed (user provides login info and clicks the "Login" button)
             return await _loginTaskCompletionSrc.Task;
@@ -138,9 +138,9 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
             finally
             {
                 // Dismiss the login controls.
-                if (Application.Current.MainPage.Navigation.NavigationStack.OfType<LoginPage>().Any())
+                if (Navigation.NavigationStack.OfType<LoginPage>().Any())
                 {
-                    await Application.Current.MainPage.Navigation.PopAsync();
+                    await Navigation.PopAsync();
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
         private void LoginCanceled(object sender, EventArgs e)
         {
             // Dismiss the login controls.
-            Application.Current.MainPage.Navigation.PopAsync();
+            Navigation.PopAsync();
 
             // Cancel the task completion source task.
             _loginTaskCompletionSrc.TrySetCanceled();

--- a/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/CustomDictionaryStyle/CustomDictionaryStyle.xaml.cs
@@ -73,7 +73,7 @@ namespace ArcGIS.Samples.CustomDictionaryStyle
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGIS.Samples.FeatureLayerExtrusion
             catch (Exception ex)
             {
                 // Something went wrong, display the error.
-                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolStylesFromWebStyles/SymbolStylesFromWebStyles.xaml.cs
@@ -81,7 +81,7 @@ namespace ArcGIS.Samples.SymbolStylesFromWebStyles
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
@@ -157,7 +157,7 @@ namespace ArcGIS.Samples.SymbolsFromMobileStyle
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -174,7 +174,7 @@ namespace ArcGIS.Samples.SymbolsFromMobileStyle
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.xaml.cs
@@ -97,7 +97,7 @@ namespace ArcGIS.Samples.SymbolsFromMobileStyle
                     // Create an image source from the swatch.
                     Stream imageBuffer = await swatch.GetEncodedBufferAsync();
                     byte[] imageData = new byte[imageBuffer.Length];
-                    imageBuffer.Read(imageData, 0, imageData.Length);
+                    imageBuffer.ReadExactly(imageData);
                     ImageSource symbolImage = ImageSource.FromStream(() => new MemoryStream(imageData));
 
                     // Create a symbol layer info object to represent the symbol in the list.

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml.cs
@@ -100,7 +100,7 @@ namespace ArcGIS.Samples.ConfigureSubnetworkTrace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 
@@ -199,11 +199,11 @@ namespace ArcGIS.Samples.ConfigureSubnetworkTrace
                 UtilityElementTraceResult elementResult = results?.FirstOrDefault() as UtilityElementTraceResult;
 
                 // Display the number of elements found by the trace.
-                await Application.Current.MainPage.DisplayAlert("Trace Result", $"`{elementResult?.Elements?.Count ?? 0}` elements found.", "OK");
+                await DisplayAlert("Trace Result", $"`{elementResult?.Elements?.Count ?? 0}` elements found.", "OK");
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", $"{ex.Message}\nFor a working barrier condition, try \"Transformer Load\" Equal \"15\".", "OK");
+                await DisplayAlert("Error", $"{ex.Message}\nFor a working barrier condition, try \"Transformer Load\" Equal \"15\".", "OK");
             }
         }
 
@@ -257,7 +257,7 @@ namespace ArcGIS.Samples.ConfigureSubnetworkTrace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -127,7 +127,7 @@ namespace ArcGIS.Samples.DisplayUtilityAssociations
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
 
@@ -177,7 +177,7 @@ namespace ArcGIS.Samples.DisplayUtilityAssociations
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
         }
     }

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityNetworkContainer/DisplayUtilityNetworkContainer.xaml.cs
@@ -105,7 +105,7 @@ namespace ArcGIS.Samples.DisplayUtilityNetworkContainer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {
@@ -201,7 +201,7 @@ namespace ArcGIS.Samples.DisplayUtilityNetworkContainer
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+                await DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml.cs
@@ -136,7 +136,7 @@ namespace ArcGIS.Samples.PerformValveIsolationTrace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
             finally
             {
@@ -187,7 +187,7 @@ namespace ArcGIS.Samples.PerformValveIsolationTrace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
             finally
             {
@@ -209,7 +209,7 @@ namespace ArcGIS.Samples.PerformValveIsolationTrace
         {
             // Load the terminals into a DisplayActionSheet and await the user's selection.
             var terminalArray = terminals.Select(x => x.Name).ToArray();
-            string choice = await Application.Current.MainPage.DisplayActionSheet("Choose junction.", "Cancel", null, terminalArray);
+            string choice = await DisplayActionSheet("Choose junction.", "Cancel", null, terminalArray);
             if (terminalArray.Contains(choice))
             {
                 return terminals.Single(x => x.Name == choice);
@@ -279,7 +279,7 @@ namespace ArcGIS.Samples.PerformValveIsolationTrace
             }
             catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
             finally
             {

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -125,7 +125,7 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
             catch (Exception ex)
             {
                 Status.Text = "Loading Utility Network failed...";
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
             finally
             {
@@ -209,7 +209,7 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
             catch (Exception ex)
             {
                 Status.Text = "Identifying locations failed.";
-                await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
             }
             finally
             {
@@ -222,7 +222,7 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
         {
             // Load the terminals into a DisplayActionSheet and await the user's selection.
             var terminalArray = terminals.Select(x => x.Name).ToArray();
-            string choice = await Application.Current.MainPage.DisplayActionSheet("Choose junction.", "Cancel", null, terminalArray);
+            string choice = await DisplayActionSheet("Choose junction.", "Cancel", null, terminalArray);
             if (terminalArray.Contains(choice))
             {
                 return terminals.Single(x => x.Name == choice);
@@ -294,11 +294,11 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
                 Status.Text = "Trace failed...";
                 if (ex is ArcGISWebException && ex.Message == null)
                 {
-                    await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, "Trace failed.", "OK");
+                    await DisplayAlert(ex.GetType().Name, "Trace failed.", "OK");
                 }
                 else
                 {
-                    await Application.Current.MainPage.DisplayAlert(ex.GetType().Name, ex.Message, "OK");
+                    await DisplayAlert(ex.GetType().Name, ex.Message, "OK");
                 }
             }
             finally
@@ -314,7 +314,7 @@ namespace ArcGIS.Samples.TraceUtilityNetwork
             {
                 // Prompt the user to select a type of trace.
                 var traceTypes = new string[] { "Connected", "Subnetwork", "Upstream", "Downstream" };
-                string choice = await Application.Current.MainPage.DisplayActionSheet("Choose type of trace", "Cancel", null, traceTypes);
+                string choice = await DisplayActionSheet("Choose type of trace", "Cancel", null, traceTypes);
 
                 // Set the selected trace type.
                 _selectedTraceType = (UtilityTraceType)Enum.Parse(typeof(UtilityTraceType), choice);

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml
@@ -37,7 +37,7 @@
                        Grid.Row="2"
                        Grid.ColumnSpan="2"
                        Text="Loading sample..." />
-                <ActivityIndicator x:Name="IsBusy"
+                <ActivityIndicator x:Name="BusyIndicator"
                                    Grid.Row="3"
                                    Grid.ColumnSpan="2"
                                    Height="15"

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml.cs
@@ -101,7 +101,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
         {
             try
             {
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
                 Status.Text = "Loading a webmap...";
 
                 // Add credential for this webmap.
@@ -137,7 +137,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
                 var sgdb =
                     utilityNetwork.ServiceGeodatabase
                     ?? throw new InvalidOperationException("Expected a service geodatabase");
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
 
                 // Restrict editing and tracing on a random branch.
                 var parameters = new ServiceVersionParameters();
@@ -237,7 +237,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             }
             finally
             {
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 
@@ -251,7 +251,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
 
                 if (utilityNetwork.Definition.Capabilities.SupportsNetworkState)
                 {
-                    IsBusy.IsVisible = true;
+                    BusyIndicator.IsVisible = true;
                     Status.Text = "Getting utility network state...";
 
                     var state = await utilityNetwork.GetStateAsync();
@@ -287,7 +287,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             }
             finally
             {
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 
@@ -306,7 +306,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
                     ?.Extent
                     ?? throw new InvalidOperationException("Expected current extent");
 
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
                 Status.Text = "Validating utility network topology...";
 
                 // Get the validation result.
@@ -328,7 +328,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             }
             finally
             {
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 
@@ -336,7 +336,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
         {
             try
             {
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
                 Status.Text = "Identifying feature to edit...";
 
                 // Perform an identify to determine if a user tapped on a feature.
@@ -408,7 +408,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             }
             finally
             {
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 
@@ -432,7 +432,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
                     return;
                 }
 
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
 
                 Status.Text = "Updating feature...";
                 _featureToEdit.Attributes[fieldName] = codedValue.Code;
@@ -473,7 +473,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
                 AttributePicker.IsVisible = false;
                 ClearBtn.IsEnabled = false;
                 ValidateBtn.IsEnabled = true;
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 
@@ -486,7 +486,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             try
             {
                 // Update the UI.
-                IsBusy.IsVisible = true;
+                BusyIndicator.IsVisible = true;
                 Status.Text = $"Running a downstream trace...";
 
                 // Clear previous selection from the layers.
@@ -528,7 +528,7 @@ namespace ArcGIS.Samples.ValidateUtilityNetworkTopology
             }
             finally
             {
-                IsBusy.IsVisible = false;
+                BusyIndicator.IsVisible = false;
             }
         }
 

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -112,7 +112,7 @@ namespace ArcGIS
             base.OnNavigatedFrom(args);
 
             // Check that the navigation is backward from the sample and not forward into another page in the sample.
-            if (!Application.Current.MainPage.Navigation.NavigationStack.OfType<SamplePage>().Any())
+            if (!Navigation.NavigationStack.OfType<SamplePage>().Any())
             {
                 // Explicit cleanup of the Map and SceneView instead of waiting for garbage collector can help when
                 // lots of geoviews are being opened and closed
@@ -223,7 +223,7 @@ namespace ArcGIS
 #if IOS
                 // Need to set the viewport on iOS to scale page correctly.
                 "<meta name=\"viewport\" content=\"width=" +
-                Application.Current.MainPage.Width +
+                Width +
                 ", shrink-to-fit=YES\">" +
 #endif
                 "</head><body class=\"markdown-body\">" +

--- a/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SamplePage.xaml.cs
@@ -35,7 +35,6 @@ namespace ArcGIS
     {
         private ContentPage _sampleContent;
         private Assembly _assembly;
-        private int _lastViewedFileIndex;
 
         // single-instance webviews reused on each view, to avoid a memory leak in webview
         private static WebView DescriptionView = new WebView();
@@ -487,10 +486,11 @@ namespace ArcGIS
 
         private void OpenSourceCodePage()
         {
+            // Initially show the C# code.
             if (SourceFiles.Any())
             {
-                _selectedFile = SourceFiles[_lastViewedFileIndex];
-                FilePicker.SelectedIndex = _lastViewedFileIndex;
+                _selectedFile = SourceFiles[0];
+                FilePicker.SelectedIndex = 0;
             }
 
             SourceCodePage.IsVisible = true;

--- a/src/MAUI/Maui.Samples/Views/SettingsPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/SettingsPage.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGIS
 #if IOS
             // Need to set the viewport on iOS to scale page correctly.
             string viewportHTML = "<meta name=\"viewport\" content=\"width=" +
-                Application.Current.MainPage.Width +
+                Width +
                 ", shrink-to-fit=YES\">";
 #endif
             string htmlStart = $"<!doctype html><head><style>{cssContent}body {{padding: 10px; }}</style>";
@@ -152,12 +152,12 @@ namespace ArcGIS
                 }
                 catch (OperationCanceledException)
                 {
-                    await Application.Current.MainPage.DisplayAlert(string.Empty, "Download canceled", "OK");
+                    await DisplayAlert(string.Empty, "Download canceled", "OK");
                 }
                 catch (Exception exception)
                 {
                     Debug.WriteLine(exception);
-                    await Application.Current.MainPage.DisplayAlert("Error", "Couldn't download data for that sample", "OK");
+                    await DisplayAlert("Error", "Couldn't download data for that sample", "OK");
                 }
                 finally
                 {
@@ -207,12 +207,12 @@ namespace ArcGIS
                             Debug.WriteLine(ex.Message);
                         }
                     }
-                    await Application.Current.MainPage.DisplayAlert("Success", $"Offline data deleted for {sampleInfo.SampleName}", "OK");
+                    await DisplayAlert("Success", $"Offline data deleted for {sampleInfo.SampleName}", "OK");
                 }
                 catch (Exception exception)
                 {
                     Debug.WriteLine(exception);
-                    await Application.Current.MainPage.DisplayAlert("Error", $"Couldn't delete offline data.", "OK");
+                    await DisplayAlert("Error", $"Couldn't delete offline data.", "OK");
                 }
                 finally
                 {
@@ -248,7 +248,7 @@ namespace ArcGIS
                             }
                             catch (OperationCanceledException)
                             {
-                                await Application.Current.MainPage.DisplayAlert(string.Empty, "Download canceled", "OK");
+                                await DisplayAlert(string.Empty, "Download canceled", "OK");
                                 return;
                             }
                             catch (Exception ex)
@@ -259,12 +259,12 @@ namespace ArcGIS
                         }
                     }
                 }
-                await Application.Current.MainPage.DisplayAlert(string.Empty, "All data downloaded", "OK");
+                await DisplayAlert(string.Empty, "All data downloaded", "OK");
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
-                await Application.Current.MainPage.DisplayAlert("Error", exception.Message, "OK");
+                await DisplayAlert("Error", exception.Message, "OK");
             }
             finally
             {
@@ -293,12 +293,12 @@ namespace ArcGIS
                     }
                 }
 
-                await Application.Current.MainPage.DisplayAlert("Success", "All data deleted", "OK");
+                await DisplayAlert("Success", "All data deleted", "OK");
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
-                await Application.Current.MainPage.DisplayAlert("Error", exception.Message, "OK");
+                await DisplayAlert("Error", exception.Message, "OK");
             }
             finally
             {

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -23,7 +23,7 @@ namespace ArcGIS.Samples.Shared.Models
 #if NETFX_CORE
         private string _pathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
 #else
-        private string _pathStub = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private string _pathStub = System.IO.Path.GetDirectoryName(AppContext.BaseDirectory);
 #endif
 
         /// <summary>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -87,8 +87,4 @@
     </ItemGroup>
     <Copy SourceFiles="@(XamlFiles)" DestinationFolder="$(OutDir)%(RecursiveDir)" SkipUnchangedFiles="True" />
   </Target>
-  <!-- Workaround for https://github.com/dotnet/core/issues/7176 -->
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.WindowsDesktop.App;Microsoft.WindowsDesktop.App.WPF;Microsoft.WindowsDesktop.App.WindowsForms" TargetingPackVersion="6.0.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Addresses warnings introduced by .NET 9 upgrade and Maps SDK 200.7.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
