### PR TITLE
Fix UI for `Create and edit geometries`

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml
@@ -31,7 +31,7 @@
                         Grid.Row="1"
                         IsVisible="False"
                         MaximumHeightRequest="400">
-                <Grid ColumnDefinitions="auto, auto"
+                <Grid ColumnDefinitions="*, *"
                       ColumnSpacing="5"
                       RowDefinitions="auto, auto, auto, auto, auto, auto, auto"
                       RowSpacing="5">
@@ -79,12 +79,14 @@
                         <Border.StrokeShape>
                             <RoundRectangle CornerRadius="5" />
                         </Border.StrokeShape>
-                        <HorizontalStackLayout>
+                        <Grid ColumnDefinitions="35,*">
                             <CheckBox x:Name="UniformScaleCheckBox"
                                       Margin="3,0,5,0"
                                       CheckedChanged="CheckBox_CheckedChanged" />
-                            <Label Text="Uniform Scale" VerticalOptions="Center" />
-                        </HorizontalStackLayout>
+                            <Label Grid.Column="1"
+                                   Text="Uniform Scale"
+                                   VerticalOptions="Center" />
+                        </Grid>
                     </Border>
                     <Button Grid.Row="4"
                             Clicked="UndoButton_Click"


### PR DESCRIPTION
# Description

Fixes sample UI which broke during .NET 9 upgrade.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
