### PR TITLE
Fixes app navigation

### DIFF
--- a/src/MAUI/Maui.Samples/AppShell.xaml.cs
+++ b/src/MAUI/Maui.Samples/AppShell.xaml.cs
@@ -36,7 +36,7 @@ public partial class AppShell : Shell
         ApiKeyStatus status = await ApiKeyManager.CheckKeyValidity();
         if (status != ApiKeyStatus.Valid)
         {
-            await Navigation.PushAsync(new ApiKeyPage(), true);
+            await Shell.Current.Navigation.PushAsync(new ApiKeyPage(), true);
         }
     }
     #endregion

--- a/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -98,7 +98,7 @@ namespace ArcGIS.Samples.ChangeSublayerVisibility
                 };
 
                 // Navigate to the sublayers page
-                await Navigation.PushAsync(sublayersPage);
+                await Shell.Current.Navigation.PushAsync(sublayersPage);
             }
             catch (Exception ex)
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGIS.Samples.IdentifyKmlFeatures
                 }
 
                 // Show a page with the HTML content
-                await Navigation.PushAsync(new KmlIdentifyResultDisplayPage(firstIdentifiedPlacemark.BalloonContent));
+                await Shell.Current.Navigation.PushAsync(new KmlIdentifyResultDisplayPage(firstIdentifiedPlacemark.BalloonContent), false);
             }
             catch (Exception ex)
             {

--- a/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
@@ -101,7 +101,7 @@ namespace ArcGIS.Samples.WmsIdentify
                 }
 
                 // Show a page with the HTML content
-                await Navigation.PushAsync(new WmsIdentifyResultDisplayPage(htmlContent));
+                await Shell.Current.Navigation.PushAsync(new WmsIdentifyResultDisplayPage(htmlContent));
             }
             catch (Exception ex)
             {

--- a/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGIS.Samples.AuthorMap
             mapInputForm.OnSaveClicked += SaveMapAsync;
 
             // Navigate to the SaveMapPage UI.
-            Navigation.PushAsync(mapInputForm);
+            Shell.Current.Navigation.PushAsync(mapInputForm);
         }
 
         // Event handler to get information entered by the user and save the map.

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml.cs
@@ -94,7 +94,7 @@ namespace ArcGIS.Samples.ManageBookmarks
             try
             {
                 // Prompt the user for the new bookmark name.
-                string name = await DisplayPromptAsync("New bookmark", "Enter name for new bookmark");
+                string name = await Application.Current.Windows[0].Page.DisplayPromptAsync("New bookmark", "Enter name for new bookmark");
 
                 // Exit if the name is empty
                 if (string.IsNullOrEmpty(name))

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -307,7 +307,7 @@ namespace ArcGIS.Samples.RouteAroundBarriers
 
         private async Task ShowDirectionsTask()
         {
-            await Navigation.PushAsync(_directionsPage);
+            await Shell.Current.Navigation.PushAsync(_directionsPage);
         }
 
         private async Task<PictureMarkerSymbol> GetPictureMarker()

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -97,7 +97,7 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
 
             // Show the login controls on the UI thread.
             // OnLoginInfoEntered event will return the values entered (username and password).
-            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () => await Navigation.PushAsync(_loginPage));
+            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(async () => await Shell.Current.Navigation.PushAsync(_loginPage));
 
             // Return the login task, the result will be ready when completed (user provides login info and clicks the "Login" button)
             return await _loginTaskCompletionSrc.Task;

--- a/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Views/CategoryPage.xaml.cs
@@ -60,12 +60,12 @@ public partial class CategoryPage : ContentPage
 
     private async void SettingsClicked(object sender, EventArgs e)
     {
-        await Navigation.PushAsync(new SettingsPage(), true);
+        await Shell.Current.Navigation.PushAsync(new SettingsPage(), true);
     }
 
     private async void SearchClicked(object sender, EventArgs e)
     {
-        await Navigation.PushAsync(new SearchPage(), false);
+        await Shell.Current.Navigation.PushAsync(new SearchPage(), false);
     }
 
     // The favorites icon can flicker when using a pen as pointer.


### PR DESCRIPTION
# Description

Adds required `Shell.Current.Navigation` to `PushAsync()` method calls. This fixes several samples where pages weren't being navigated to.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

Note: tested all samples impacted on Windows, tested two on Android

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
