### PR TITLE
Fixed InEnabled binding forSave button in EditFeatureForms MAUI sample

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeaturesUsingFeatureForms/EditFeaturesUsingFeatureForms.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeaturesUsingFeatureForms/EditFeaturesUsingFeatureForms.xaml
@@ -5,8 +5,7 @@
              xmlns:toolkit="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui">
     <Grid>
         <esriUI:MapView x:Name="MyMapView"
-                        GeoViewTapped="MyMapView_GeoViewTapped"
-                        Style="{DynamicResource EsriSampleGeoView}" />
+                        GeoViewTapped="MyMapView_GeoViewTapped" />
         <Grid x:Name="FeatureFormPanel"
               IsVisible="False" Padding="20"
               BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
@@ -25,7 +24,7 @@
                 <Button Text="Save"
                         Grid.Column="0"
                         Clicked="SaveButton_Clicked"
-                        IsEnabled="{Binding Source={x:Reference FeatureFormView}, Path=IsValid}" />
+                        IsEnabled="{Binding Source={x:Reference FeatureFormViewPanel}, Path=IsValid}" />
                 <Button Text="Cancel"
                         Grid.Column="1"
                         Clicked="CancelButton_Clicked" />


### PR DESCRIPTION
# Description

Removed dynamic styling resource.
Updated the "Save" button's `IsEnabled` property to bind to `FeatureFormViewPanel` for validation state.

## Type of change



- Bug fix


## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
