### PR TITLE
Fixed ComboBox in `Create and Edit Geometries` WinUI sample

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml
@@ -65,7 +65,6 @@
                       Grid.ColumnSpan="2"
                       HorizontalAlignment="Stretch"
                       Background="White"
-                      DisplayMemberPath="Key"
                       SelectionChanged="ToolComboBox_SelectionChanged"
                       ToolTipService.ToolTip="Tools" />
             <Border Grid.Row="3"

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -107,7 +107,7 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
             MyMapView.GeometryEditor = _geometryEditor;
 
             // Create vertex and freehand tools for the combo box.
-            ToolComboBox.ItemsSource = _toolDictionary = new Dictionary<string, object>()
+            _toolDictionary = new Dictionary<string, object>()
             {
                 { "Vertex Tool", new VertexTool() },
                 { "Reticle Vertex Tool", new ReticleVertexTool() },
@@ -117,6 +117,8 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
                 { "Rectangle Shape Tool", ShapeTool.Create(ShapeToolType.Rectangle) },
                 { "Triangle Shape Tool", ShapeTool.Create(ShapeToolType.Triangle) }
             };
+
+            ToolComboBox.ItemsSource = _toolDictionary.Keys;
 
             // Have the vertex tool selected by default.
             ToolComboBox.SelectedIndex = 0;
@@ -196,7 +198,8 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
         private void ToolComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             // Set the geometry editor tool based on the new selection.
-            _geometryEditor.Tool = ((KeyValuePair<string, object>)ToolComboBox.SelectedItem).Value as GeometryEditorTool;
+            GeometryEditorTool tool = _toolDictionary[ToolComboBox.SelectedItem.ToString()] as GeometryEditorTool;
+            _geometryEditor.Tool = tool;
 
             // Account for case when vertex tool is selected and geometry editor is started with a polyline or polygon geometry type.
             // Ensure point and multipoint buttons are only enabled when the selected tool is a vertex tool.


### PR DESCRIPTION
# Description

Since ComboBox is unable to work with Dictionaries in WinAppSDK version 1.6, changed the ComboBox Itemsource to point to Keys of dictionary to fix the issue. 

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
