### PR TITLE
Fixed `Map image layer sublayer visibility` sample by assigning XAML root to ContentDialog.

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -98,6 +98,7 @@ namespace ArcGIS.WinUI.Samples.ChangeSublayerVisibility
                 dialog.PrimaryButtonClick += (s, a) => dialog.Hide();
 
                 // Show dialog as a full screen overlay.
+                dialog.XamlRoot = this.XamlRoot;
                 await dialog.ShowAsync();
             }
             catch (Exception ex)


### PR DESCRIPTION
# Description

Fixed `Map image layer sublayer visibility` sample by assigning XAML root to ContentDialog.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
