### PR TITLE
Fixing `Create and Save map` sample to enable basemap selection on map

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -71,13 +71,13 @@ namespace ArcGIS.WinUI.Samples.AuthorMap
             // Update the UI with basemaps and layers
             BasemapListBox.ItemsSource = _basemapNames;
 
-            OperationalLayerListBox.ItemsSource = _operationalLayerUrls;
-
             // Add a listener for changes in the selected basemap.
             BasemapListBox.SelectionChanged += BasemapSelectionChanged;
 
             // Update the extent labels whenever the view point (extent) changes
             MyMapView.ViewpointChanged += (s, evt) => UpdateViewExtentLabels();
+
+            OperationalLayerListBox.ItemsSource = _operationalLayerUrls;
         }
 
         #region UI event handlers


### PR DESCRIPTION
# Description

Refactor OperationalLayerListBox assignment location to fix a bug related to not able to initialize SelectionChanged event for BasemapListBox.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
