### PR TITLE
TokenSecuredChallenge - login prompt won't disappear 

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
@@ -51,7 +51,7 @@
 
         private void CancelButtonClicked(object sender, EventArgs e)
         {
-            // Fire the OnCanceled event to let the calling code no the login was canceled.
+            // Fire the OnCanceled event to let the calling code know the login was canceled.
             if (OnCanceled != null)
             {
                 OnCanceled(this, null);

--- a/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -138,9 +138,9 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
             finally
             {
                 // Dismiss the login controls.
-                if (Navigation.NavigationStack.OfType<LoginPage>().Any())
+                if (Shell.Current.Navigation.NavigationStack.OfType<LoginPage>().Any())
                 {
-                    await Navigation.PopAsync();
+                    _ = Shell.Current.Navigation.PopAsync();
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace ArcGIS.Samples.TokenSecuredChallenge
         private void LoginCanceled(object sender, EventArgs e)
         {
             // Dismiss the login controls.
-            Navigation.PopAsync();
+            _ = Shell.Current.Navigation.PopAsync();
 
             // Cancel the task completion source task.
             _loginTaskCompletionSrc.TrySetCanceled();


### PR DESCRIPTION
# Description

Fixes navigation pop calls from the login prompt page.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files