### PR TITLE
Remove reference to non-existent property

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
@@ -19,9 +19,8 @@ Tap a feature on the map to open a sheet displaying the feature form. Select for
 3. Create a `FeatureForm` object using the identified `ArcGISFeature`.
   * **Note:** If the feature's `FeatureLayer`, `ArcGISFeatureTable`, or the `SubtypeSublayer` has an authored `FeatureFormDefinition`, then this definition will be used to create the `FeatureForm`. If such a definition is not found, a default definition is generated.
 4. Use the `FeatureForm` toolkit component to display the feature form configuration by providing the created `featureForm` object.
-5. Optionally, you can add a `ValidationErrorVisibility` option to the `FeatureForm` toolkit component that determines the visibility of validation errors.
-6. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
-7. To commit edits on the service geodatabase:
+5. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
+6. To commit edits on the service geodatabase:
     1. Call `FinishEditingAsync()` to save edits to the database.
     2. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.ServiceGeodatabase`.
     3. Verify the service geodatabase can commit changes back to the service using `serviceGeodatabase.ServiceInfo?.CanUseServiceGeodatabaseApplyEdits`

--- a/src/WPF/WPF.Viewer/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
+++ b/src/WPF/WPF.Viewer/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
@@ -19,9 +19,8 @@ Tap a feature on the map to open a sheet displaying the feature form. Select for
 3. Create a `FeatureForm` object using the identified `ArcGISFeature`.
   * **Note:** If the feature's `FeatureLayer`, `ArcGISFeatureTable`, or the `SubtypeSublayer` has an authored `FeatureFormDefinition`, then this definition will be used to create the `FeatureForm`. If such a definition is not found, a default definition is generated.
 4. Use the `FeatureForm` toolkit component to display the feature form configuration by providing the created `featureForm` object.
-5. Optionally, you can add a `ValidationErrorVisibility` option to the `FeatureForm` toolkit component that determines the visibility of validation errors.
-6. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
-7. To commit edits on the service geodatabase:
+5. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
+6. To commit edits on the service geodatabase:
     1. Call `FinishEditingAsync()` to save edits to the database.
     2. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.ServiceGeodatabase`.
     3. Verify the service geodatabase can commit changes back to the service using `serviceGeodatabase.ServiceInfo?.CanUseServiceGeodatabaseApplyEdits`

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/EditFeaturesUsingFeatureForms/readme.md
@@ -19,9 +19,8 @@ Tap a feature on the map to open a sheet displaying the feature form. Select for
 3. Create a `FeatureForm` object using the identified `ArcGISFeature`.
   * **Note:** If the feature's `FeatureLayer`, `ArcGISFeatureTable`, or the `SubtypeSublayer` has an authored `FeatureFormDefinition`, then this definition will be used to create the `FeatureForm`. If such a definition is not found, a default definition is generated.
 4. Use the `FeatureForm` toolkit component to display the feature form configuration by providing the created `featureForm` object.
-5. Optionally, you can add a `ValidationErrorVisibility` option to the `FeatureForm` toolkit component that determines the visibility of validation errors.
-6. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
-7. To commit edits on the service geodatabase:
+5. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.ValidationErrors` to verify that there are no errors.
+6. To commit edits on the service geodatabase:
     1. Call `FinishEditingAsync()` to save edits to the database.
     2. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.ServiceGeodatabase`.
     3. Verify the service geodatabase can commit changes back to the service using `serviceGeodatabase.ServiceInfo?.CanUseServiceGeodatabaseApplyEdits`


### PR DESCRIPTION
# Description

The property mentioned does not exist.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
