### PR TITLE
Removing "/latest/" from previously modified redirect links

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/ManageFeatures/readme.metadata.json
@@ -29,11 +29,11 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/maui/sample-code/manage-features.htm",
-        "/net/latest/maui/sample-code/add-features.htm",
-        "/net/latest/maui/sample-code/delete-features.htm",
-        "/net/latest/maui/sample-code/update-attributes.htm",
-        "/net/latest/maui/sample-code/update-geometries.htm"
+        "/net/maui/sample-code/manage-features.htm",
+        "/net/maui/sample-code/add-features.htm",
+        "/net/maui/sample-code/delete-features.htm",
+        "/net/maui/sample-code/update-attributes.htm",
+        "/net/maui/sample-code/update-geometries.htm"
     ],
     "relevant_apis": [
         "Feature",

--- a/src/MAUI/Maui.Samples/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
@@ -24,10 +24,10 @@
         "9d2987a825c646468b3ce7512fb76e2d"
     ],
     "redirect_from": [
-        "/net/latest/maui/sample-code/configure-electronic-navigational-charts.htm",
-        "/net/latest/maui/sample-code/select-enc-features.htm",
-        "/net/latest/maui/sample-code/change-enc-display-settings.htm",
-        "/net/latest/maui/sample-code/add-enc-exchange-set.htm"
+        "/net/maui/sample-code/configure-electronic-navigational-charts.htm",
+        "/net/maui/sample-code/select-enc-features.htm",
+        "/net/maui/sample-code/change-enc-display-settings.htm",
+        "/net/maui/sample-code/add-enc-exchange-set.htm"
     ],
     "relevant_apis": [
         "EncCell",

--- a/src/MAUI/Maui.Samples/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
@@ -20,9 +20,9 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/maui/sample-code/picture-marker-symbol.htm",
-        "/net/latest/maui/sample-code/style-geometry-types-with-symbols.htm",
-        "/net/latest/maui/sample-code/simple-marker-symbol.htm"
+        "/net/maui/sample-code/picture-marker-symbol.htm",
+        "/net/maui/sample-code/style-geometry-types-with-symbols.htm",
+        "/net/maui/sample-code/simple-marker-symbol.htm"
     ],
     "relevant_apis": [
         "Geometry",

--- a/src/WPF/WPF.Viewer/Samples/Data/ManageFeatures/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Data/ManageFeatures/readme.metadata.json
@@ -29,11 +29,11 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/wpf/sample-code/manage-features.htm",
-        "/net/latest/wpf/sample-code/add-features.htm",
-        "/net/latest/wpf/sample-code/delete-features.htm",
-        "/net/latest/wpf/sample-code/update-attributes.htm",
-        "/net/latest/wpf/sample-code/update-geometries.htm"
+        "/net/wpf/sample-code/manage-features.htm",
+        "/net/wpf/sample-code/add-features.htm",
+        "/net/wpf/sample-code/delete-features.htm",
+        "/net/wpf/sample-code/update-attributes.htm",
+        "/net/wpf/sample-code/update-geometries.htm"
     ],
     "relevant_apis": [
         "Feature",

--- a/src/WPF/WPF.Viewer/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
@@ -20,9 +20,9 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/wpf/sample-code/picture-marker-symbol.htm",
-        "/net/latest/wpf/sample-code/style-geometry-types-with-symbols.htm",
-        "/net/latest/wpf/sample-code/simple-marker-symbol.htm"
+        "/net/wpf/sample-code/picture-marker-symbol.htm",
+        "/net/wpf/sample-code/style-geometry-types-with-symbols.htm",
+        "/net/wpf/sample-code/simple-marker-symbol.htm"
     ],
     "relevant_apis": [
         "Geometry",

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/DistanceMeasurement/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Analysis/DistanceMeasurement/readme.metadata.json
@@ -14,7 +14,7 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/winui/sample-code/distance-measurement-analysis.htm"
+        "/net/winui/sample-code/distance-measurement-analysis.htm"
     ],
     "relevant_apis": [
         "AnalysisOverlay",

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/ManageFeatures/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/ManageFeatures/readme.metadata.json
@@ -29,11 +29,11 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/winui/sample-code/manage-features.htm",
-        "/net/latest/winui/sample-code/add-features.htm",
-        "/net/latest/winui/sample-code/delete-features.htm",
-        "/net/latest/winui/sample-code/update-attributes.htm",
-        "/net/latest/winui/sample-code/update-geometries.htm"
+        "/net/winui/sample-code/manage-features.htm",
+        "/net/winui/sample-code/add-features.htm",
+        "/net/winui/sample-code/delete-features.htm",
+        "/net/winui/sample-code/update-attributes.htm",
+        "/net/winui/sample-code/update-geometries.htm"
     ],
     "relevant_apis": [
         "Feature",

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
@@ -24,10 +24,10 @@
         "9d2987a825c646468b3ce7512fb76e2d"
     ],
     "redirect_from": [
-        "/net/latest/winui/sample-code/configure-electronic-navigational-charts.htm",
-        "/net/latest/winui/sample-code/select-enc-features.htm",
-        "/net/latest/winui/sample-code/change-enc-display-settings.htm",
-        "/net/latest/winui/sample-code/add-enc-exchange-set.htm"
+        "/net/winui/sample-code/configure-electronic-navigational-charts.htm",
+        "/net/winui/sample-code/select-enc-features.htm",
+        "/net/winui/sample-code/change-enc-display-settings.htm",
+        "/net/winui/sample-code/add-enc-exchange-set.htm"
     ],
     "relevant_apis": [
         "EncCell",

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Symbology/StyleGeometryTypesWithSymbols/readme.metadata.json
@@ -20,9 +20,9 @@
     ],
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/winui/sample-code/picture-marker-symbol.htm",
-        "/net/latest/winui/sample-code/style-geometry-types-with-symbols.htm",
-        "/net/latest/winui/sample-code/simple-marker-symbol.htm"
+        "/net/winui/sample-code/picture-marker-symbol.htm",
+        "/net/winui/sample-code/style-geometry-types-with-symbols.htm",
+        "/net/winui/sample-code/simple-marker-symbol.htm"
     ],
     "relevant_apis": [
         "Geometry",


### PR DESCRIPTION
# Description

Redirect links have been updated per issue description in necessary scripts.

## Type of change

<!--- Delete any that don't apply -->
- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
