### PR TITLE
Carlos/open street map sample

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -1,4 +1,4 @@
-# OpenStreetMap layer
+# OpenStreetMap layer (Deprecated in 200.8)
 
 Add OpenStreetMap as a basemap layer.
 

--- a/src/WPF/WPF.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/WPF/WPF.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -1,4 +1,4 @@
-# OpenStreetMap layer
+# OpenStreetMap layer (Deprecated in 200.8)
 
 Add OpenStreetMap as a basemap layer.
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -1,4 +1,4 @@
-# OpenStreetMap layer
+# OpenStreetMap layer (Deprecated in 200.8)
 
 Add OpenStreetMap as a basemap layer.
 

--- a/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
+++ b/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
@@ -22,7 +22,6 @@ exception_proper_nouns = {
     'Network Link',
     'OAuth',
     'OAuth2',
-    'Open Street Map',
     'OpenStreetMap',
     'Play a KML Tour',
     'Portal',


### PR DESCRIPTION
# Description

This PR is for OpenStreetMap layer in Layers category. OpenStreetMap is the qualified proper noun for the project, instead of "Open Street Map" (with whitespace).

NOTE: This naming convention was already the case for .NET, just needed to go in and fix the style checker and add the deprecation alert in the readme files.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
