### PR TITLE
Metadata sync fixes

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
@@ -21,7 +21,7 @@
     "redirect_from": [
         "/net/maui/sample-code/read-geopackage.htm",
         "/net/latest/maui/sample-code/read-geopackage.htm",
-        "/net/maui/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
+        "/net/latest/maui/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
     ],
     "relevant_apis": [
         "FeatureLayer",
@@ -31,8 +31,7 @@
         "GeoPackageFeatureTable",
         "GeoPackageRaster",
         "RasterLayer"
-
-  ],
+    ],
     "snippets": [
         "AddRastersAndFeatureTablesFromGeopackage.xaml.cs",
         "AddRastersAndFeatureTablesFromGeopackage.xaml"

--- a/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/GeodesicOperations/readme.metadata.json
@@ -19,7 +19,7 @@
     "relevant_apis": [
         "GeometryEngine.DensifyGeodetic",
         "GeometryEngine.DistanceGeodetic"
-  ],
+    ],
     "snippets": [
         "GeodesicOperations.xaml.cs",
         "GeodesicOperations.xaml"

--- a/src/MAUI/Maui.Samples/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
@@ -19,15 +19,15 @@
     "redirect_from": [
         "/net/maui/sample-code/scene-layer-url.htm",
         "/net/latest/maui/sample-code/scene-layer-url.htm",
-        "/net/maui/sample-code/add-scene-layer-with-elevation.htm"
-  ],
+        "/net/latest/maui/sample-code/add-scene-layer-with-elevation.htm"
+    ],
     "relevant_apis": [
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
         "Scene",
         "SceneView",
         "Surface"
-  ],
+    ],
     "snippets": [
         "AddSceneLayerWithElevation.xaml.cs",
         "AddSceneLayerWithElevation.xaml"

--- a/src/MAUI/Maui.Samples/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ConfigureElectronicNavigationalCharts/readme.metadata.json
@@ -27,10 +27,10 @@
         "/net/latest/maui/sample-code/select-enc-features.htm",
         "/net/latest/maui/sample-code/change-enc-display-settings.htm",
         "/net/latest/maui/sample-code/add-enc-exchange-set.htm",
-        "/net/maui/sample-code/configure-electronic-navigational-charts.htm",
         "/net/maui/sample-code/select-enc-features.htm",
         "/net/maui/sample-code/change-enc-display-settings.htm",
-        "/net/maui/sample-code/add-enc-exchange-set.htm"
+        "/net/maui/sample-code/add-enc-exchange-set.htm",
+        "/net/latest/maui/sample-code/configure-electronic-navigational-charts.htm"
     ],
     "relevant_apis": [
         "EncCell",

--- a/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Layers/RasterHillshade/readme.metadata.json
@@ -16,7 +16,7 @@
     ],
     "offline_data": [
         "ae9739163a76437ea02482e1a807b806"
-  ],
+    ],
     "redirect_from": [
         "/net/latest/maui/sample-code/hillshade-renderer.htm"
     ],

--- a/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -17,7 +17,7 @@ namespace ArcGIS.Samples.SceneLayerSelection
         category: "Layers",
         description: "Identify features in a scene to select.",
         instructions: "Tap on a building in the scene layer to select it. Deselect buildings by clicking away from the buildings.",
-        tags: new[] { "3D", "Brest", "buildings", "identify", "model", "query", "search", "select" })]
+        tags: new[] { "3D", "buildings", "identify", "model", "query", "search", "select" })]
     public partial class SceneLayerSelection : ContentPage
     {
         public SceneLayerSelection()

--- a/src/MAUI/Maui.Samples/Samples/Map/SetBasemap/SetBasemap.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetBasemap/SetBasemap.xaml.cs
@@ -14,9 +14,9 @@ namespace ArcGIS.Samples.SetBasemap
     [ArcGIS.Samples.Shared.Attributes.Sample(
         name: "Set basemap",
         category: "Map",
-        description: "Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.",
-        instructions: "When the basemap gallery appears, select a basemap to be displayed.",
-        tags: new[] { "basemap", "basemap gallery", "map", "toolkit" })]
+        description: "Change a map's basemap.",
+        instructions: "Use the drop down menu to select the active basemap from the list of available basemaps.",
+        tags: new[] { "basemap", "basemap gallery", "basemap style", "map", "toolkit" })]
     public partial class SetBasemap : ContentPage
     {
         public SetBasemap()

--- a/src/MAUI/Maui.Samples/Samples/Map/SetBasemap/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Map/SetBasemap/readme.metadata.json
@@ -12,19 +12,19 @@
         "basemap style",
         "map",
         "toolkit"
-  ],
+    ],
     "offline_data": [],
     "redirect_from": [
         "/net/maui/sample-code/change-basemap.htm",
         "/net/latest/maui/sample-code/change-basemap.htm",
-        "/net/maui/sample-code/set-basemap.htm"
-  ],
+        "/net/latest/maui/sample-code/set-basemap.htm"
+    ],
     "relevant_apis": [
         "BasemapGallery",
         "BasemapStyle",
         "Map",
         "MapView"
-  ],
+    ],
     "snippets": [
         "SetBasemap.xaml.cs",
         "SetBasemap.xaml"

--- a/src/MAUI/readme.md
+++ b/src/MAUI/readme.md
@@ -13,6 +13,7 @@
 ## Data
 
 * [Add features with contingent values](Maui.Samples/Samples/Data/AddFeaturesWithContingentValues) - Create and add features whose attribute values satisfy a predefined set of contingencies.
+* [Add rasters and feature tables from geopackage](Maui.Samples/Samples/Data/AddRastersAndFeatureTablesFromGeopackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Create KML multi-track](Maui.Samples/Samples/Data/CreateKmlMultiTrack) - Create, save and preview a KML multi-track, captured from a location data source.
 * [Create mobile geodatabase](Maui.Samples/Samples/Data/CreateMobileGeodatabase) - Create and share a mobile geodatabase.
 * [Edit and sync features](Maui.Samples/Samples/Data/EditAndSyncFeatures) - Synchronize offline edits with a feature service.
@@ -26,8 +27,6 @@
 * [List related features](Maui.Samples/Samples/Data/ListRelatedFeatures) - List features related to the selected feature.
 * [Manage features](Maui.Samples/Samples/Data/ManageFeatures) - Create, update, and delete features to manage a feature layer.
 * [Query features with Arcade expression](Maui.Samples/Samples/Data/QueryFeaturesWithArcadeExpression) - Query features on a map using an Arcade expression.
-* [Raster layer (GeoPackage)](Maui.Samples/Samples/Data/RasterLayerGeoPackage) - Display a raster contained in a GeoPackage.
-* [Read GeoPackage](Maui.Samples/Samples/Data/ReadGeoPackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Read shapefile metadata](Maui.Samples/Samples/Data/ReadShapefileMetadata) - Read a shapefile and display its metadata.
 * [Statistical query](Maui.Samples/Samples/Data/StatisticalQuery) - Query a table to get aggregated statistics back for a specific field.
 * [Statistical query group and sort](Maui.Samples/Samples/Data/StatsQueryGroupAndSort) - Query a feature table for statistics, grouping and sorting by different fields.
@@ -79,6 +78,7 @@
 * [Add custom dynamic entity data source](Maui.Samples/Samples/Layers/AddCustomDynamicEntityDataSource) - Create a custom dynamic entity data source and display it using a dynamic entity layer.
 * [Add dynamic entity layer](Maui.Samples/Samples/Layers/AddDynamicEntityLayer) - Display data from an ArcGIS stream service using a dynamic entity layer.
 * [Add integrated mesh layer](Maui.Samples/Samples/Layers/AddAnIntegratedMeshLayer) - View an integrated mesh layer from a scene service.
+* [Add scene layer with elevation](Maui.Samples/Samples/Layers/AddSceneLayerWithElevation) - Display an ArcGIS scene layer from a URL.
 * [Add vector tiled layer from custom style](Maui.Samples/Samples/Layers/AddVectorTiledLayerFromCustomStyle) - Load ArcGIS vector tiled layers using custom styles.
 * [Apply mosaic rule to rasters](Maui.Samples/Samples/Layers/ApplyMosaicRule) - Apply mosaic rule to a mosaic dataset of rasters.
 * [Apply raster function to raster from service](Maui.Samples/Samples/Layers/RasterLayerRasterFunction) - Load a raster from a service, then apply a function to it.
@@ -100,7 +100,6 @@
 * [Display KML network links](Maui.Samples/Samples/Layers/DisplayKmlNetworkLinks) - Display a file with a KML network link, including displaying any network link control messages at launch.
 * [Display OGC API collection](Maui.Samples/Samples/Layers/DisplayOACollection) - Display an OGC API feature collection and query features while navigating the map view.
 * [Display WFS layer](Maui.Samples/Samples/Layers/DisplayWfs) - Display a layer from a WFS service, requesting only features for the current extent.
-* [Display a scene](Maui.Samples/Samples/Layers/DisplayScene) - Display a scene with a terrain surface and some imagery.
 * [Display annotation](Maui.Samples/Samples/Layers/DisplayAnnotation) - Display annotation from a feature service URL.
 * [Display clusters](Maui.Samples/Samples/Layers/DisplayClusters) - Display a web map with a point feature layer that has feature reduction enabled to aggregate points into clusters.
 * [Display dimensions](Maui.Samples/Samples/Layers/DisplayDimensions) - Display dimension features from a mobile map package.
@@ -125,16 +124,15 @@
 * [List KML contents](Maui.Samples/Samples/Layers/ListKmlContents) - List the contents of a KML file.
 * [Load WFS with XML query](Maui.Samples/Samples/Layers/WfsXmlQuery) - Load a WFS feature table using an XML query.
 * [Map image layer sublayer visibility](Maui.Samples/Samples/Layers/ChangeSublayerVisibility) - Change the visibility of sublayers.
-* [Map image layer tables](Maui.Samples/Samples/Layers/MapImageLayerTables) - Find features in a spatial table related to features in a non-spatial table.
 * [OpenStreetMap layer](Maui.Samples/Samples/Layers/OpenStreetMapLayer) - Add OpenStreetMap as a basemap layer.
 * [Play KML tour](Maui.Samples/Samples/Layers/PlayKmlTours) - Play tours in KML files.
 * [Query map image sublayer](Maui.Samples/Samples/Layers/MapImageSublayerQuery) - Find features in a sublayer based on attributes and location.
+* [Query related features from non spatial table](Maui.Samples/Samples/Layers/QueryRelatedFeaturesFromNonSpatialTable) - Find features in a spatial table related to features in a non-spatial table.
 * [Query with CQL filters](Maui.Samples/Samples/Layers/QueryCQLFilters) - Query data from an OGC API feature service using CQL filters.
 * [RGB renderer](Maui.Samples/Samples/Layers/RasterRgbRenderer) - Apply an RGB renderer to a raster layer to enhance feature visibility.
 * [Raster layer (file)](Maui.Samples/Samples/Layers/RasterLayerFile) - Create and use a raster layer made from a local raster file.
 * [Raster layer (service)](Maui.Samples/Samples/Layers/RasterLayerImageServiceRaster) - Create a raster layer from a raster image service.
 * [Raster rendering rule](Maui.Samples/Samples/Layers/RasterRenderingRule) - Display a raster on a map and apply different rendering rules to that raster.
-* [Scene layer (URL)](Maui.Samples/Samples/Layers/SceneLayerUrl) - Display an ArcGIS scene layer from a URL.
 * [Scene layer selection](Maui.Samples/Samples/Layers/SceneLayerSelection) - Identify features in a scene to select.
 * [Show labels on layers](Maui.Samples/Samples/Layers/ShowLabelsOnLayer) - Display custom labels on a feature layer.
 * [Stretch renderer](Maui.Samples/Samples/Layers/ChangeStretchRenderer) - Use a stretch renderer to enhance the visual contrast of raster data for analysis.
@@ -157,7 +155,6 @@
 
 * [Apply scheduled updates to preplanned map area](Maui.Samples/Samples/Map/ApplyScheduledUpdates) - Apply scheduled updates to a downloaded preplanned map area.
 * [Browse building floors](Maui.Samples/Samples/Map/BrowseBuildingFloors) - Display and browse through building floors from a floor-aware web map.
-* [Change basemap](Maui.Samples/Samples/Map/ChangeBasemap) - Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.
 * [Configure basemap style parameters](Maui.Samples/Samples/Map/ConfigureBasemapStyleParameters) - Apply basemap style parameters customization for a basemap, such as displaying all labels in a specific language or displaying every label in their corresponding local language.
 * [Create and save map](Maui.Samples/Samples/Map/AuthorMap) - Create and save a map as an ArcGIS `PortalItem` (i.e. web map).
 * [Create dynamic basemap gallery](Maui.Samples/Samples/Map/CreateDynamicBasemapGallery) - Implement a basemap gallery that automatically retrieves the latest customization options from the basemap styles service.
@@ -178,6 +175,7 @@
 * [Open map URL](Maui.Samples/Samples/Map/OpenMapURL) - Display a web map.
 * [Open mobile map package](Maui.Samples/Samples/Map/OpenMobileMap) - Display a map from a mobile map package.
 * [Search for webmap](Maui.Samples/Samples/Map/SearchPortalMaps) - Find webmap portal items by using a search term.
+* [Set basemap](Maui.Samples/Samples/Map/SetBasemap) - Change a map's basemap.
 * [Set initial map location](Maui.Samples/Samples/Map/SetInitialMapLocation) - Display a basemap centered at an initial location and scale.
 * [Set max extent](Maui.Samples/Samples/Map/SetMaxExtent) - Limit the view of a map to a particular area.
 * [Set min & max scale](Maui.Samples/Samples/Map/SetMinMaxScale) - Restrict zooming between specific scale ranges.

--- a/src/WPF/WPF.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
@@ -21,7 +21,7 @@
     "redirect_from": [
         "/net/wpf/sample-code/read-geopackage.htm",
         "/net/latest/wpf/sample-code/read-geopackage.htm",
-        "/net/wpf/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
+        "/net/latest/wpf/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
     ],
     "relevant_apis": [
         "FeatureLayer",

--- a/src/WPF/WPF.Viewer/Samples/Geometry/GeodesicOperations/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Geometry/GeodesicOperations/readme.metadata.json
@@ -19,7 +19,7 @@
     "relevant_apis": [
         "GeometryEngine.DensifyGeodetic",
         "GeometryEngine.DistanceGeodetic"
-  ],
+    ],
     "snippets": [
         "GeodesicOperations.xaml.cs",
         "GeodesicOperations.xaml"

--- a/src/WPF/WPF.Viewer/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
@@ -19,15 +19,15 @@
     "redirect_from": [
         "/net/wpf/sample-code/scene-layer-url.htm",
         "/net/latest/wpf/sample-code/scene-layer-url.htm",
-        "/net/wpf/sample-code/add-scene-layer-with-elevation.htm"
-  ],
+        "/net/latest/wpf/sample-code/add-scene-layer-with-elevation.htm"
+    ],
     "relevant_apis": [
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
         "Scene",
         "SceneView",
         "Surface"
-  ],
+    ],
     "snippets": [
         "AddSceneLayerWithElevation.xaml.cs",
         "AddSceneLayerWithElevation.xaml"

--- a/src/WPF/WPF.Viewer/Samples/Layers/RasterHillshade/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Layers/RasterHillshade/readme.metadata.json
@@ -15,8 +15,8 @@
         "visualization"
     ],
     "offline_data": [
-      "ae9739163a76437ea02482e1a807b806"
-  ],
+        "ae9739163a76437ea02482e1a807b806"
+    ],
     "redirect_from": [
         "/net/latest/wpf/sample-code/hillshade-renderer.htm"
     ],

--- a/src/WPF/WPF.Viewer/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -21,7 +21,7 @@ namespace ArcGIS.WPF.Samples.SceneLayerSelection
         category: "Layers",
         description: "Identify features in a scene to select.",
         instructions: "Click on a building in the scene layer to select it. Deselect buildings by clicking away from the buildings.",
-        tags: new[] { "3D", "Brest", "buildings", "identify", "model", "query", "search", "select" })]
+        tags: new[] { "3D", "buildings", "identify", "model", "query", "search", "select" })]
     public partial class SceneLayerSelection
     {
         public SceneLayerSelection()

--- a/src/WPF/WPF.Viewer/Samples/Map/SetBasemap/SetBasemap.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Map/SetBasemap/SetBasemap.xaml.cs
@@ -14,9 +14,9 @@ namespace ArcGIS.WPF.Samples.SetBasemap
     [ArcGIS.Samples.Shared.Attributes.Sample(
         name: "Set basemap",
         category: "Map",
-        description: "Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.",
-        instructions: "When the basemap gallery appears, select a basemap to be displayed.",
-        tags: new[] { "basemap", "basemap gallery", "map", "toolkit" })]
+        description: "Change a map's basemap.",
+        instructions: "Use the drop down menu to select the active basemap from the list of available basemaps.",
+        tags: new[] { "basemap", "basemap gallery", "basemap style", "map", "toolkit" })]
     public partial class SetBasemap
     {
         public SetBasemap()

--- a/src/WPF/WPF.Viewer/Samples/Map/SetBasemap/readme.metadata.json
+++ b/src/WPF/WPF.Viewer/Samples/Map/SetBasemap/readme.metadata.json
@@ -12,19 +12,19 @@
         "basemap style",
         "map",
         "toolkit"
-  ],
+    ],
     "offline_data": [],
     "redirect_from": [
         "/net/wpf/sample-code/change-basemap.htm",
         "/net/latest/wpf/sample-code/change-basemap.htm",
-        "/net/wpf/sample-code/set-basemap.htm"
-  ],
+        "/net/latest/wpf/sample-code/set-basemap.htm"
+    ],
     "relevant_apis": [
         "BasemapGallery",
         "BasemapStyle",
         "Map",
         "MapView"
-  ],
+    ],
     "snippets": [
         "SetBasemap.xaml.cs",
         "SetBasemap.xaml"

--- a/src/WPF/readme.md
+++ b/src/WPF/readme.md
@@ -13,6 +13,7 @@
 ## Data
 
 * [Add features with contingent values](WPF.Viewer/Samples/Data/AddFeaturesWithContingentValues) - Create and add features whose attribute values satisfy a predefined set of contingencies.
+* [Add rasters and feature tables from geopackage](WPF.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Create KML multi-track](WPF.Viewer/Samples/Data/CreateKmlMultiTrack) - Create, save and preview a KML multi-track, captured from a location data source.
 * [Create mobile geodatabase](WPF.Viewer/Samples/Data/CreateMobileGeodatabase) - Create and share a mobile geodatabase.
 * [Edit and sync features](WPF.Viewer/Samples/Data/EditAndSyncFeatures) - Synchronize offline edits with a feature service.
@@ -26,8 +27,6 @@
 * [List related features](WPF.Viewer/Samples/Data/ListRelatedFeatures) - List features related to the selected feature.
 * [Manage features](WPF.Viewer/Samples/Data/ManageFeatures) - Create, update, and delete features to manage a feature layer.
 * [Query features with Arcade expression](WPF.Viewer/Samples/Data/QueryFeaturesWithArcadeExpression) - Query features on a map using an Arcade expression.
-* [Raster layer (GeoPackage)](WPF.Viewer/Samples/Data/RasterLayerGeoPackage) - Display a raster contained in a GeoPackage.
-* [Read GeoPackage](WPF.Viewer/Samples/Data/ReadGeoPackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Read shapefile metadata](WPF.Viewer/Samples/Data/ReadShapefileMetadata) - Read a shapefile and display its metadata.
 * [Statistical query](WPF.Viewer/Samples/Data/StatisticalQuery) - Query a table to get aggregated statistics back for a specific field.
 * [Statistical query group and sort](WPF.Viewer/Samples/Data/StatsQueryGroupAndSort) - Query a feature table for statistics, grouping and sorting by different fields.
@@ -79,6 +78,7 @@
 * [Add custom dynamic entity data source](WPF.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource) - Create a custom dynamic entity data source and display it using a dynamic entity layer.
 * [Add dynamic entity layer](WPF.Viewer/Samples/Layers/AddDynamicEntityLayer) - Display data from an ArcGIS stream service using a dynamic entity layer.
 * [Add integrated mesh layer](WPF.Viewer/Samples/Layers/AddAnIntegratedMeshLayer) - View an integrated mesh layer from a scene service.
+* [Add scene layer with elevation](WPF.Viewer/Samples/Layers/AddSceneLayerWithElevation) - Display an ArcGIS scene layer from a URL.
 * [Add vector tiled layer from custom style](WPF.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle) - Load ArcGIS vector tiled layers using custom styles.
 * [Apply mosaic rule to rasters](WPF.Viewer/Samples/Layers/ApplyMosaicRule) - Apply mosaic rule to a mosaic dataset of rasters.
 * [Apply raster function to raster from service](WPF.Viewer/Samples/Layers/RasterLayerRasterFunction) - Load a raster from a service, then apply a function to it.
@@ -100,7 +100,6 @@
 * [Display KML network links](WPF.Viewer/Samples/Layers/DisplayKmlNetworkLinks) - Display a file with a KML network link, including displaying any network link control messages at launch.
 * [Display OGC API collection](WPF.Viewer/Samples/Layers/DisplayOACollection) - Display an OGC API feature collection and query features while navigating the map view.
 * [Display WFS layer](WPF.Viewer/Samples/Layers/DisplayWfs) - Display a layer from a WFS service, requesting only features for the current extent.
-* [Display a scene](WPF.Viewer/Samples/Layers/DisplayScene) - Display a scene with a terrain surface and some imagery.
 * [Display annotation](WPF.Viewer/Samples/Layers/DisplayAnnotation) - Display annotation from a feature service URL.
 * [Display clusters](WPF.Viewer/Samples/Layers/DisplayClusters) - Display a web map with a point feature layer that has feature reduction enabled to aggregate points into clusters.
 * [Display dimensions](WPF.Viewer/Samples/Layers/DisplayDimensions) - Display dimension features from a mobile map package.
@@ -125,16 +124,15 @@
 * [List KML contents](WPF.Viewer/Samples/Layers/ListKmlContents) - List the contents of a KML file.
 * [Load WFS with XML query](WPF.Viewer/Samples/Layers/WfsXmlQuery) - Load a WFS feature table using an XML query.
 * [Map image layer sublayer visibility](WPF.Viewer/Samples/Layers/ChangeSublayerVisibility) - Change the visibility of sublayers.
-* [Map image layer tables](WPF.Viewer/Samples/Layers/MapImageLayerTables) - Find features in a spatial table related to features in a non-spatial table.
 * [OpenStreetMap layer](WPF.Viewer/Samples/Layers/OpenStreetMapLayer) - Add OpenStreetMap as a basemap layer.
 * [Play KML tour](WPF.Viewer/Samples/Layers/PlayKmlTours) - Play tours in KML files.
 * [Query map image sublayer](WPF.Viewer/Samples/Layers/MapImageSublayerQuery) - Find features in a sublayer based on attributes and location.
+* [Query related features from non spatial table](WPF.Viewer/Samples/Layers/QueryRelatedFeaturesFromNonSpatialTable) - Find features in a spatial table related to features in a non-spatial table.
 * [Query with CQL filters](WPF.Viewer/Samples/Layers/QueryCQLFilters) - Query data from an OGC API feature service using CQL filters.
 * [RGB renderer](WPF.Viewer/Samples/Layers/RasterRgbRenderer) - Apply an RGB renderer to a raster layer to enhance feature visibility.
 * [Raster layer (file)](WPF.Viewer/Samples/Layers/RasterLayerFile) - Create and use a raster layer made from a local raster file.
 * [Raster layer (service)](WPF.Viewer/Samples/Layers/RasterLayerImageServiceRaster) - Create a raster layer from a raster image service.
 * [Raster rendering rule](WPF.Viewer/Samples/Layers/RasterRenderingRule) - Display a raster on a map and apply different rendering rules to that raster.
-* [Scene layer (URL)](WPF.Viewer/Samples/Layers/SceneLayerUrl) - Display an ArcGIS scene layer from a URL.
 * [Scene layer selection](WPF.Viewer/Samples/Layers/SceneLayerSelection) - Identify features in a scene to select.
 * [Show labels on layers](WPF.Viewer/Samples/Layers/ShowLabelsOnLayer) - Display custom labels on a feature layer.
 * [Stretch renderer](WPF.Viewer/Samples/Layers/ChangeStretchRenderer) - Use a stretch renderer to enhance the visual contrast of raster data for analysis.
@@ -164,7 +162,6 @@
 
 * [Apply scheduled updates to preplanned map area](WPF.Viewer/Samples/Map/ApplyScheduledUpdates) - Apply scheduled updates to a downloaded preplanned map area.
 * [Browse building floors](WPF.Viewer/Samples/Map/BrowseBuildingFloors) - Display and browse through building floors from a floor-aware web map.
-* [Change basemap](WPF.Viewer/Samples/Map/ChangeBasemap) - Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.
 * [Configure basemap style parameters](WPF.Viewer/Samples/Map/ConfigureBasemapStyleParameters) - Apply basemap style parameters customization for a basemap, such as displaying all labels in a specific language or displaying every label in their corresponding local language.
 * [Create and save map](WPF.Viewer/Samples/Map/AuthorMap) - Create and save a map as an ArcGIS `PortalItem` (i.e. web map).
 * [Create dynamic basemap gallery](WPF.Viewer/Samples/Map/CreateDynamicBasemapGallery) - Implement a basemap gallery that automatically retrieves the latest customization options from the basemap styles service.
@@ -185,6 +182,7 @@
 * [Open map URL](WPF.Viewer/Samples/Map/OpenMapURL) - Display a web map.
 * [Open mobile map package](WPF.Viewer/Samples/Map/OpenMobileMap) - Display a map from a mobile map package.
 * [Search for webmap](WPF.Viewer/Samples/Map/SearchPortalMaps) - Find webmap portal items by using a search term.
+* [Set basemap](WPF.Viewer/Samples/Map/SetBasemap) - Change a map's basemap.
 * [Set initial map location](WPF.Viewer/Samples/Map/SetInitialMapLocation) - Display a basemap centered at an initial location and scale.
 * [Set max extent](WPF.Viewer/Samples/Map/SetMaxExtent) - Limit the view of a map to a particular area.
 * [Set min & max scale](WPF.Viewer/Samples/Map/SetMinMaxScale) - Restrict zooming between specific scale ranges.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage/readme.metadata.json
@@ -21,7 +21,7 @@
     "redirect_from": [
         "/net/winui/sample-code/read-geopackage.htm",
         "/net/latest/winui/sample-code/read-geopackage.htm",
-        "/net/winui/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
+        "/net/latest/winui/sample-code/add-rasters-and-feature-tables-from-geopackage.htm"
     ],
     "relevant_apis": [
         "FeatureLayer",
@@ -31,7 +31,7 @@
         "GeoPackageFeatureTable",
         "GeoPackageRaster",
         "RasterLayer"
-  ],
+    ],
     "snippets": [
         "AddRastersAndFeatureTablesFromGeopackage.xaml.cs",
         "AddRastersAndFeatureTablesFromGeopackage.xaml"

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/GeodesicOperations/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/GeodesicOperations/readme.metadata.json
@@ -19,7 +19,7 @@
     "relevant_apis": [
         "GeometryEngine.DensifyGeodetic",
         "GeometryEngine.DistanceGeodetic"
-  ],
+    ],
     "snippets": [
         "GeodesicOperations.xaml.cs",
         "GeodesicOperations.xaml"

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/AddSceneLayerWithElevation/readme.metadata.json
@@ -19,15 +19,15 @@
     "redirect_from": [
         "/net/winui/sample-code/scene-layer-url.htm",
         "/net/latest/winui/sample-code/scene-layer-url.htm",
-        "/net/winui/sample-code/add-scene-layer-with-elevation.htm"
-  ],
+        "/net/latest/winui/sample-code/add-scene-layer-with-elevation.htm"
+    ],
     "relevant_apis": [
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
         "Scene",
         "SceneView",
         "Surface"
-  ],
+    ],
     "snippets": [
         "AddSceneLayerWithElevation.xaml.cs",
         "AddSceneLayerWithElevation.xaml"

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/RasterHillshade/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/RasterHillshade/readme.metadata.json
@@ -16,7 +16,7 @@
     ],
     "offline_data": [
         "ae9739163a76437ea02482e1a807b806"
-  ],
+    ],
     "redirect_from": [
         "/net/latest/winui/sample-code/hillshade-renderer.htm"
     ],

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -21,7 +21,7 @@ namespace ArcGIS.WinUI.Samples.SceneLayerSelection
         category: "Layers",
         description: "Identify features in a scene to select.",
         instructions: "Click on a building in the scene layer to select it. Deselect buildings by clicking away from the buildings.",
-        tags: new[] { "3D", "Brest", "buildings", "identify", "model", "query", "search", "select" })]
+        tags: new[] { "3D", "buildings", "identify", "model", "query", "search", "select" })]
     public partial class SceneLayerSelection
     {
         public SceneLayerSelection()

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/SetBasemap/SetBasemap.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/SetBasemap/SetBasemap.xaml.cs
@@ -16,9 +16,9 @@ namespace ArcGIS.WinUI.Samples.SetBasemap
     [ArcGIS.Samples.Shared.Attributes.Sample(
         name: "Set basemap",
         category: "Map",
-        description: "Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.",
+        description: "Change a map's basemap.",
         instructions: "Use the drop down menu to select the active basemap from the list of available basemaps.",
-        tags: new[] { "basemap", "map" })]
+        tags: new[] { "basemap", "basemap gallery", "basemap style", "map", "toolkit" })]
     public partial class SetBasemap
     {
         // Dictionary that associates names with basemaps.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/SetBasemap/readme.metadata.json
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/SetBasemap/readme.metadata.json
@@ -12,19 +12,19 @@
         "basemap style",
         "map",
         "toolkit"
-  ],
+    ],
     "offline_data": [],
     "redirect_from": [
         "/net/winui/sample-code/change-basemap.htm",
         "/net/latest/winui/sample-code/change-basemap.htm",
-        "/net/winui/sample-code/set-basemap.htm"
-  ],
+        "/net/latest/winui/sample-code/set-basemap.htm"
+    ],
     "relevant_apis": [
         "BasemapGallery",
         "BasemapStyle",
         "Map",
         "MapView"
-  ],
+    ],
     "snippets": [
         "SetBasemap.xaml.cs",
         "SetBasemap.xaml"

--- a/src/WinUI/readme.md
+++ b/src/WinUI/readme.md
@@ -13,6 +13,7 @@
 ## Data
 
 * [Add features with contingent values](ArcGIS.WinUI.Viewer/Samples/Data/AddFeaturesWithContingentValues) - Create and add features whose attribute values satisfy a predefined set of contingencies.
+* [Add rasters and feature tables from geopackage](ArcGIS.WinUI.Viewer/Samples/Data/AddRastersAndFeatureTablesFromGeopackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Create KML multi-track](ArcGIS.WinUI.Viewer/Samples/Data/CreateKmlMultiTrack) - Create, save and preview a KML multi-track, captured from a location data source.
 * [Create mobile geodatabase](ArcGIS.WinUI.Viewer/Samples/Data/CreateMobileGeodatabase) - Create and share a mobile geodatabase.
 * [Edit and sync features](ArcGIS.WinUI.Viewer/Samples/Data/EditAndSyncFeatures) - Synchronize offline edits with a feature service.
@@ -26,8 +27,6 @@
 * [List related features](ArcGIS.WinUI.Viewer/Samples/Data/ListRelatedFeatures) - List features related to the selected feature.
 * [Manage features](ArcGIS.WinUI.Viewer/Samples/Data/ManageFeatures) - Create, update, and delete features to manage a feature layer.
 * [Query features with Arcade expression](ArcGIS.WinUI.Viewer/Samples/Data/QueryFeaturesWithArcadeExpression) - Query features on a map using an Arcade expression.
-* [Raster layer (GeoPackage)](ArcGIS.WinUI.Viewer/Samples/Data/RasterLayerGeoPackage) - Display a raster contained in a GeoPackage.
-* [Read GeoPackage](ArcGIS.WinUI.Viewer/Samples/Data/ReadGeoPackage) - Add rasters and feature tables from a GeoPackage to a map.
 * [Read shapefile metadata](ArcGIS.WinUI.Viewer/Samples/Data/ReadShapefileMetadata) - Read a shapefile and display its metadata.
 * [Statistical query](ArcGIS.WinUI.Viewer/Samples/Data/StatisticalQuery) - Query a table to get aggregated statistics back for a specific field.
 * [Statistical query group and sort](ArcGIS.WinUI.Viewer/Samples/Data/StatsQueryGroupAndSort) - Query a feature table for statistics, grouping and sorting by different fields.
@@ -79,6 +78,7 @@
 * [Add custom dynamic entity data source](ArcGIS.WinUI.Viewer/Samples/Layers/AddCustomDynamicEntityDataSource) - Create a custom dynamic entity data source and display it using a dynamic entity layer.
 * [Add dynamic entity layer](ArcGIS.WinUI.Viewer/Samples/Layers/AddDynamicEntityLayer) - Display data from an ArcGIS stream service using a dynamic entity layer.
 * [Add integrated mesh layer](ArcGIS.WinUI.Viewer/Samples/Layers/AddAnIntegratedMeshLayer) - View an integrated mesh layer from a scene service.
+* [Add scene layer with elevation](ArcGIS.WinUI.Viewer/Samples/Layers/AddSceneLayerWithElevation) - Display an ArcGIS scene layer from a URL.
 * [Add vector tiled layer from custom style](ArcGIS.WinUI.Viewer/Samples/Layers/AddVectorTiledLayerFromCustomStyle) - Load ArcGIS vector tiled layers using custom styles.
 * [Apply mosaic rule to rasters](ArcGIS.WinUI.Viewer/Samples/Layers/ApplyMosaicRule) - Apply mosaic rule to a mosaic dataset of rasters.
 * [Apply raster function to raster from service](ArcGIS.WinUI.Viewer/Samples/Layers/RasterLayerRasterFunction) - Load a raster from a service, then apply a function to it.
@@ -100,7 +100,6 @@
 * [Display KML network links](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayKmlNetworkLinks) - Display a file with a KML network link, including displaying any network link control messages at launch.
 * [Display OGC API collection](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayOACollection) - Display an OGC API feature collection and query features while navigating the map view.
 * [Display WFS layer](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayWfs) - Display a layer from a WFS service, requesting only features for the current extent.
-* [Display a scene](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayScene) - Display a scene with a terrain surface and some imagery.
 * [Display annotation](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayAnnotation) - Display annotation from a feature service URL.
 * [Display clusters](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayClusters) - Display a web map with a point feature layer that has feature reduction enabled to aggregate points into clusters.
 * [Display dimensions](ArcGIS.WinUI.Viewer/Samples/Layers/DisplayDimensions) - Display dimension features from a mobile map package.
@@ -125,16 +124,15 @@
 * [List KML contents](ArcGIS.WinUI.Viewer/Samples/Layers/ListKmlContents) - List the contents of a KML file.
 * [Load WFS with XML query](ArcGIS.WinUI.Viewer/Samples/Layers/WfsXmlQuery) - Load a WFS feature table using an XML query.
 * [Map image layer sublayer visibility](ArcGIS.WinUI.Viewer/Samples/Layers/ChangeSublayerVisibility) - Change the visibility of sublayers.
-* [Map image layer tables](ArcGIS.WinUI.Viewer/Samples/Layers/MapImageLayerTables) - Find features in a spatial table related to features in a non-spatial table.
 * [OpenStreetMap layer](ArcGIS.WinUI.Viewer/Samples/Layers/OpenStreetMapLayer) - Add OpenStreetMap as a basemap layer.
 * [Play KML tour](ArcGIS.WinUI.Viewer/Samples/Layers/PlayKmlTours) - Play tours in KML files.
 * [Query map image sublayer](ArcGIS.WinUI.Viewer/Samples/Layers/MapImageSublayerQuery) - Find features in a sublayer based on attributes and location.
+* [Query related features from non spatial table](ArcGIS.WinUI.Viewer/Samples/Layers/QueryRelatedFeaturesFromNonSpatialTable) - Find features in a spatial table related to features in a non-spatial table.
 * [Query with CQL filters](ArcGIS.WinUI.Viewer/Samples/Layers/QueryCQLFilters) - Query data from an OGC API feature service using CQL filters.
 * [RGB renderer](ArcGIS.WinUI.Viewer/Samples/Layers/RasterRgbRenderer) - Apply an RGB renderer to a raster layer to enhance feature visibility.
 * [Raster layer (file)](ArcGIS.WinUI.Viewer/Samples/Layers/RasterLayerFile) - Create and use a raster layer made from a local raster file.
 * [Raster layer (service)](ArcGIS.WinUI.Viewer/Samples/Layers/RasterLayerImageServiceRaster) - Create a raster layer from a raster image service.
 * [Raster rendering rule](ArcGIS.WinUI.Viewer/Samples/Layers/RasterRenderingRule) - Display a raster on a map and apply different rendering rules to that raster.
-* [Scene layer (URL)](ArcGIS.WinUI.Viewer/Samples/Layers/SceneLayerUrl) - Display an ArcGIS scene layer from a URL.
 * [Scene layer selection](ArcGIS.WinUI.Viewer/Samples/Layers/SceneLayerSelection) - Identify features in a scene to select.
 * [Show labels on layers](ArcGIS.WinUI.Viewer/Samples/Layers/ShowLabelsOnLayer) - Display custom labels on a feature layer.
 * [Stretch renderer](ArcGIS.WinUI.Viewer/Samples/Layers/ChangeStretchRenderer) - Use a stretch renderer to enhance the visual contrast of raster data for analysis.
@@ -161,7 +159,6 @@
 
 * [Apply scheduled updates to preplanned map area](ArcGIS.WinUI.Viewer/Samples/Map/ApplyScheduledUpdates) - Apply scheduled updates to a downloaded preplanned map area.
 * [Browse building floors](ArcGIS.WinUI.Viewer/Samples/Map/BrowseBuildingFloors) - Display and browse through building floors from a floor-aware web map.
-* [Change basemap](ArcGIS.WinUI.Viewer/Samples/Map/ChangeBasemap) - Change a map's basemap. A basemap is beneath all layers on a `Map` and is used to provide visual reference for the operational layers.
 * [Configure basemap style parameters](ArcGIS.WinUI.Viewer/Samples/Map/ConfigureBasemapStyleParameters) - Apply basemap style parameters customization for a basemap, such as displaying all labels in a specific language or displaying every label in their corresponding local language.
 * [Create and save map](ArcGIS.WinUI.Viewer/Samples/Map/AuthorMap) - Create and save a map as an ArcGIS `PortalItem` (i.e. web map).
 * [Create dynamic basemap gallery](ArcGIS.WinUI.Viewer/Samples/Map/CreateDynamicBasemapGallery) - Implement a basemap gallery that automatically retrieves the latest customization options from the basemap styles service.
@@ -181,6 +178,7 @@
 * [Open map URL](ArcGIS.WinUI.Viewer/Samples/Map/OpenMapURL) - Display a web map.
 * [Open mobile map package](ArcGIS.WinUI.Viewer/Samples/Map/OpenMobileMap) - Display a map from a mobile map package.
 * [Search for webmap](ArcGIS.WinUI.Viewer/Samples/Map/SearchPortalMaps) - Find webmap portal items by using a search term.
+* [Set basemap](ArcGIS.WinUI.Viewer/Samples/Map/SetBasemap) - Change a map's basemap.
 * [Set initial map location](ArcGIS.WinUI.Viewer/Samples/Map/SetInitialMapLocation) - Display a basemap centered at an initial location and scale.
 * [Set max extent](ArcGIS.WinUI.Viewer/Samples/Map/SetMaxExtent) - Limit the view of a map to a particular area.
 * [Set min & max scale](ArcGIS.WinUI.Viewer/Samples/Map/SetMinMaxScale) - Restrict zooming between specific scale ranges.

--- a/tools/metadata_tools/process_metadata.py
+++ b/tools/metadata_tools/process_metadata.py
@@ -184,15 +184,18 @@ def main():
                 sample = sample_metadata()
                 path_to_readme = os.path.join(r, sample_dir, "readme.md")
 
+                path_to_json = os.path.join(r, sample_dir, "readme.metadata.json")
                 if not os.path.exists(path_to_readme):
                     print(f"skipping path; does not exist: {path_to_readme}")
                     continue
-                sample.populate_from_readme(platform, path_to_readme)
+                if not os.path.exists(path_to_json):
+                    print(f"skipping path; does not exist: {path_to_json}")
+                    continue
+                sample.populate_from_readme(platform, path_to_readme, path_to_json)
                 sample.populate_snippets_from_folder(platform, path_to_readme)
                 sample.populate_snippets_from_class(platform, path_to_readme)
 
                 # read existing packages from metadata
-                path_to_json = os.path.join(r, sample_dir, "readme.metadata.json")
                 if os.path.exists(path_to_json):
                     metadata_based_sample = sample_metadata()
                     metadata_based_sample.populate_from_json(path_to_json)

--- a/tools/metadata_tools/sample_metadata.py
+++ b/tools/metadata_tools/sample_metadata.py
@@ -58,7 +58,7 @@ class sample_metadata:
 
         return
     
-    def populate_from_readme(self, platform, path_to_readme):
+    def populate_from_readme(self, platform, path_to_readme, path_to_json):
         
         # read the readme content into a string
         readme_contents = ""
@@ -85,10 +85,18 @@ class sample_metadata:
         self.formal_name = pathparts[-2]
         slugged_sample_name = slugify(self.friendly_name)
 
+        # Load existing metadata if present
+        if os.path.exists(path_to_json):
+            with open(path_to_json, 'r') as json_file:
+                existing_metadata = json.load(json_file)
+                if "redirect_from" in existing_metadata:
+                    self.redirect_from = existing_metadata["redirect_from"]
+
         # populate redirect_from; it is based on a pattern
         real_platform = platform
-        redirect_string = f"/net/{real_platform.lower()}/sample-code/{slugged_sample_name}.htm"
-        self.redirect_from.append(redirect_string)
+        redirect_string = f"/net/latest/{real_platform.lower()}/sample-code/{slugged_sample_name}.htm"
+        if redirect_string not in self.redirect_from:
+            self.redirect_from.append(redirect_string)
 
         # category is the name of the folder containing the sample folder
         self.category = pathparts[-3]


### PR DESCRIPTION
- Keeps list of existing sample redirect links
- Appends a new `latest` redirect link if it doesn't currently exist
- Removes a few invalid redirect links
- Fixes metadata by running script

After committing metadata fixes and rerunning the sample_sync script, no diff was generated.