### PR TITLE
WPF: disable hyperlinks in README viewer

### DIFF
--- a/src/WPF/WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/WPF.Viewer/Description.xaml.cs
@@ -36,30 +36,8 @@ namespace ArcGIS.WPF.Viewer
             // Set the html in web browser.
             DescriptionView.DocumentText = htmlString;
 
-            // Remove the exisiting handler.
-            DescriptionView.Document.Click -= HyperlinkClick;
-
-            // Add an event handler for hyperlink clicks.
-            DescriptionView.Document.Click += HyperlinkClick;
-
-            // Create an event handler for canceling the default hyperlink behavior.
-            DescriptionView.NewWindow += (s, e) => { e.Cancel = true; };
-        }
-
-        private void HyperlinkClick(object sender, System.Windows.Forms.HtmlElementEventArgs e)
-        {
-            // Get the html element that the user clicked on.
-            System.Windows.Forms.HtmlElement src = DescriptionView.Document?.GetElementFromPoint(e.ClientMousePosition);
-
-            // Check if the element is a hyperlink.
-            if (src?.OuterHtml.StartsWith("<A href=") == true)
-            {
-                // Parse the url from the hyperlink html.
-                string url = src.OuterHtml.Split('\"')[1];
-
-                // Open the url.
-                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
-            }
+            // Disable hyperlink navigation in the web browser control.
+            DescriptionView.AllowNavigation = false;
         }
     }
 }

--- a/src/WPF/WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/WPF.Viewer/Description.xaml.cs
@@ -36,7 +36,8 @@ namespace ArcGIS.WPF.Viewer
             // Set the html in web browser.
             DescriptionView.DocumentText = htmlString;
 
-            // Disable hyperlink navigation in the web browser control.
+            // Disable navigation in the web browser control.
+            // This prevents script errors when users click links in READMEs.
             DescriptionView.AllowNavigation = false;
         }
     }


### PR DESCRIPTION
Display the README contents at all times; do not open hyperlinks within the viewer app. Prevents script errors.