### PR TITLE
Fixing blank space in popups

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/ConfigureClusters/ConfigureClusters.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/ConfigureClusters/ConfigureClusters.xaml.cs
@@ -59,7 +59,6 @@ namespace ArcGIS.Samples.ConfigureClusters
                 Command = new Command(() =>
                 {
                     PopupBackground.IsVisible = false;
-                    PopupViewer.Popup = null;
                 })
             });
 

--- a/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/DisplayClusters/DisplayClusters.xaml.cs
@@ -52,7 +52,6 @@ namespace ArcGIS.Samples.DisplayClusters
                 Command = new Command(() =>
                 {
                     PopupBackground.IsVisible = false;
-                    PopupViewer.Popup = null;
                     GeoElementsGrid.ItemsSource = null;
                     GeoElementsPanel.IsVisible = false;
                 })


### PR DESCRIPTION
# Description

This change fixes blank space introduced in popups when 2nd and following instances of popups are opened.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [ ] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
