### PR TITLE
Reorder graphics on CreateAndEditGeometries to make points selectable

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -357,11 +357,11 @@ namespace ArcGIS.Samples.CreateAndEditGeometries
             var boundaryCoordinates = (Polygon)Geometry.FromJson(_boundaryCoordinatesJson);
 
             // Add new example graphics from the geometries and symbols to the graphics overlay.
-            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road1Coordinates) { Symbol = _polylineSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road2Coordinates) { Symbol = _polylineSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
         }
 
         // Reset the UI after the editor stops.

--- a/src/UWP/ArcGIS.UWP.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/UWP/ArcGIS.UWP.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -348,11 +348,11 @@ namespace ArcGIS.UWP.Samples.CreateAndEditGeometries
             var boundaryCoordinates = (Polygon)Geometry.FromJson(_boundaryCoordinatesJson);
 
             // Add new example graphics from the geometries and symbols to the graphics overlay.
-            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road1Coordinates) { Symbol = _polylineSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road2Coordinates) { Symbol = _polylineSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
         }
 
         // Reset the UI after the editor stops.

--- a/src/WPF/WPF.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -349,11 +349,11 @@ namespace ArcGIS.WPF.Samples.CreateAndEditGeometries
             var boundaryCoordinates = (Polygon)Geometry.FromJson(_boundaryCoordinatesJson);
 
             // Add new example graphics from the geometries and symbols to the graphics overlay.
-            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road1Coordinates) { Symbol = _polylineSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road2Coordinates) { Symbol = _polylineSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
         }
 
         // Reset the UI after the editor stops.

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.xaml.cs
@@ -353,11 +353,11 @@ namespace ArcGIS.WinUI.Samples.CreateAndEditGeometries
             var boundaryCoordinates = (Polygon)Geometry.FromJson(_boundaryCoordinatesJson);
 
             // Add new example graphics from the geometries and symbols to the graphics overlay.
-            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road1Coordinates) { Symbol = _polylineSymbol });
             _graphicsOverlay.Graphics.Add(new Graphic(road2Coordinates) { Symbol = _polylineSymbol });
-            _graphicsOverlay.Graphics.Add(new Graphic(boundaryCoordinates) { Symbol = _polygonSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(houseCoordinates) { Symbol = _pointSymbol });
+            _graphicsOverlay.Graphics.Add(new Graphic(outbuildingCoordinates) { Symbol = _multiPointSymbol });
         }
 
         // Reset the UI after the editor stops.


### PR DESCRIPTION
# Description

The order in which Graphics are added to an overlay determines their default Z-order, which in turn determines which Graphic is picked by Identify operations.  In our CreateAndEditGeometries sample, the polygon graphic was added last, so it ended up top-most: partially covering other graphics, and preventing editing by always "winning" the first spot in identify results. Here's what it looks like:

![ArcGIS WinUI Viewer_fNya9nA81Z](https://github.com/user-attachments/assets/65fd4381-36c3-48e0-8b9e-23e88486ea85)

This PR places largest graphic at the bottom (polygon), lines in the middle, and point graphics on top.  This makes it possible to select/edit any graphic:

![ArcGIS WinUI Viewer_ChekoJAYiH](https://github.com/user-attachments/assets/38d6fb52-5f89-4228-a362-8bdad25bed40)


## Type of change
- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst
- [x] _UWP also exists_

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
