### PR TITLE
Rewrites the NMEA simulator to provide a proper stream without threading issues

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
             _nmeaSource.LocationChanged += LocationChanged;
             _nmeaSource.SentenceReceived += UpdateNmeaMessageLabel;
 
-            // Load the map and assign the location datasource.
+            // Load the map and assign the location data source.
             MyMapView.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(MapView.LocationDisplay))

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -194,16 +194,16 @@ namespace ArcGIS.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                //Nothing in the buffer to read
+                // Nothing in the buffer to read.
                 return 0; 
 
-            // Read all the pending bursts of data until we fill up the buffer
+            // Read all the pending bursts of data until we fill up the buffer.
             var start = _sr.BaseStream.Position;
             StringBuilder sb = new StringBuilder();
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver.
                 if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) 
                 {
                     break;
@@ -216,7 +216,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            // move the stream position forward only the amount of data we read
+            // Move the stream position forward only the amount of data we read.
             _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); 
             return count;
         }

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Location;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
+using System.Text;
 using System.Timers;
 using Location = Esri.ArcGISRuntime.Location.Location;
 using Timer = System.Timers.Timer;
@@ -29,8 +30,6 @@ namespace ArcGIS.Samples.LocationWithNMEA
     {
         private NmeaLocationDataSource _nmeaSource;
 
-        private NMEAStreamSimulator _simulatedNMEADataSource;
-
         public LocationWithNMEA()
         {
             InitializeComponent();
@@ -44,11 +43,10 @@ namespace ArcGIS.Samples.LocationWithNMEA
             MyMapView.SetViewpoint(new Viewpoint(new MapPoint(-117.191, 34.0306, SpatialReferences.Wgs84), 100000));
 
             // Create the data simulation using stored mock data.
-            _simulatedNMEADataSource = new NMEAStreamSimulator(6.0);
-            _simulatedNMEADataSource.NmeaMessageChanged += UpdateNmeaMessageLabel;
+            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
 
             // Create the NMEA data source.
-            _nmeaSource = new NmeaLocationDataSource(SpatialReferences.Wgs84);
+            _nmeaSource = NmeaLocationDataSource.FromStreamCreator((datasource) => Task.FromResult<Stream>(new SimulatedNmeaStream(nmeaMockDataPath)));
 
             // Android and WinUI:
             // To create a NmeaLocationDataSource for a bluetooth device, use the `FromBluetooth` constructor. https://developers.arcgis.com/net/api-reference/api/android/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromBluetooth.html
@@ -57,33 +55,29 @@ namespace ArcGIS.Samples.LocationWithNMEA
             // iOS:
             // When using an NMEA device on iOS, use the `NmeaLocationDataSource.FromAccessory` constructor. https://developers.arcgis.com/net/api-reference/api/ios/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromAccessory.html
 
-            // Set the location data source to use the stream from the simulator.
-            Stream messageStream = _simulatedNMEADataSource.MessageStream;
-            _nmeaSource.NmeaDataStream = messageStream;
-
             // Create an event handler to update the UI when the location changes.
             _nmeaSource.SatellitesChanged += SatellitesChanged;
             _nmeaSource.LocationChanged += LocationChanged;
+            _nmeaSource.SentenceReceived += UpdateNmeaMessageLabel;
 
-            // Start the location data source.
+            // Load the map and assign the location datasource.
+            MyMapView.LocationDisplay.DataSource = _nmeaSource;
             try
             {
                 await MyMapView.Map.LoadAsync();
-                MyMapView.LocationDisplay.DataSource = _nmeaSource;
-                await _nmeaSource.StartAsync();
             }
             catch (Exception ex)
             {
-                await Application.Current.Windows[0].Page.DisplayAlert(ex.Message.GetType().Name, ex.Message, "OK");
+                await DisplayAlert(ex.Message.GetType().Name, ex.Message, "OK");
             }
         }
 
-        private void UpdateNmeaMessageLabel(object sender, NmeaMessageEventArgs e)
+        private void UpdateNmeaMessageLabel(object sender, string message)
         {
-            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+            if (message.StartsWith("$GPRMC")) // Display the latest RMC message
             {
-                NmeaMessageLabel.Text = e.NmeaMessage;
-            });
+                Dispatcher.Dispatch(() => NmeaMessageLabel.Text = message );
+            }
         }
 
         private void SatellitesChanged(object sender, IReadOnlyList<NmeaSatelliteInfo> infos)
@@ -98,7 +92,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
                 uniqueSatelliteIds.Add(info.Id);
             }
 
-            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+            Dispatcher.Dispatch(() =>
             {
                 // Show the status information in the UI.
                 CountLabel.Text = $"Satellite count: {infos.Count}";
@@ -109,7 +103,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
 
         private void LocationChanged(object sender, Location loc)
         {
-            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+            Dispatcher.Dispatch(() =>
             {
                 // Show the status information in the UI.
                 AccuracyLabel.Text = $"Accuracy: Horizontal {string.Format("{0:0.00}", loc.HorizontalAccuracy)} meters, Vertical  {string.Format("{0:0.00}", loc.VerticalAccuracy)} meters";
@@ -121,7 +115,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
 
         private void StartClick(object sender, EventArgs e)
         {
-            _simulatedNMEADataSource.Start();
+            _nmeaSource.StartAsync();
             AccuracyLabel.Text = string.Empty;
         }
 
@@ -132,8 +126,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
 
         private void ResetClick(object sender, EventArgs e)
         {
-            _simulatedNMEADataSource.Stop();
-            _simulatedNMEADataSource.Reset();
+            _nmeaSource.StopAsync();
 
             // Reset the labels.
             AccuracyLabel.Text = "Simulation reset.";
@@ -147,92 +140,95 @@ namespace ArcGIS.Samples.LocationWithNMEA
         {
             // Stop the location data source.
             MyMapView.LocationDisplay?.DataSource?.StopAsync();
-            _simulatedNMEADataSource?.Dispose();
         }
     }
 
     /*
      * This class uses mock data (an edited recording of a real NMEA data stream) to simulate live NMEA data and create a stream.
      * For NMEA location data sources created from a Bluetooth device or serial input, you may not need to create your own stream.
-     * For any other case, you can write the data to a memory stream like below.
+     * For any other case, you can simulate the datastream from a file like below
      */
 
-    public class NMEAStreamSimulator : IDisposable
+    public class SimulatedNmeaStream : Stream
     {
-        private Timer _timer;
+        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
 
-        public Stream MessageStream;
+        private readonly Timer _timer;
 
-        private int _lineCounter = 0;
-        private const int DefaultInterval = 1000;
+        private readonly StreamReader _sr;
 
-        private string[] _nmeaStrings;
+        private int _pendingBursts = 0;
 
-        public event EventHandler<NmeaMessageEventArgs> NmeaMessageChanged;
-
-        public NMEAStreamSimulator(double speed = 1.0)
+        public SimulatedNmeaStream(string file)
         {
-            _timer = new Timer(DefaultInterval / speed);
-
             // Populate an array with all of the mock NMEA data.
-            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
-            _nmeaStrings = File.ReadAllText(nmeaMockDataPath).Split('\n');
-
-            // Create a data stream for the `NmeaLocationDataSource` to use.
-            MessageStream = new MemoryStream();
-
+            _sr = new StreamReader(file);
+            _timer = new Timer(DefaultInterval);
             _timer.Elapsed += TimerElapsed;
-        }
-
-        public void Start()
-        {
             _timer.Start();
         }
 
-        public void Stop()
+        private void TimerElapsed(object sender, ElapsedEventArgs e) => Interlocked.Increment(ref _pendingBursts);
+
+        protected override void Dispose(bool disposing)
         {
-            _timer.Stop();
-        }
-
-        public void Reset()
-        {
-            _timer.Stop();
-            _lineCounter = 0;
-        }
-
-        private void TimerElapsed(object sender, ElapsedEventArgs e)
-        {
-            // Get the next NMEA string and append return and newline characters to it.
-            string nmeaString = $"{_nmeaStrings[_lineCounter]}\r\n";
-
-            NmeaMessageChanged?.Invoke(this, new NmeaMessageEventArgs { NmeaMessage = nmeaString });
-
-            // Check if the start of a new location message.
-            if (nmeaString.StartsWith("$GPGGA"))
+            if (disposing)
             {
-                // Flush any existing NMEA data from the stream.
-                MessageStream.Flush();
+                // Dispose of the timer and stream.
+                _timer.Stop();
+                _timer.Dispose();
+                _sr.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Implementation of a custom System.IO.Stream 
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_pendingBursts == 0)
+                return 0; //Nothing in the buffer to read
+
+            // Read all the pending bursts of data until we fill up the buffer
+            var start = _sr.BaseStream.Position;
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
+            {
+                string line = _sr.ReadLine();
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                {
+                    break;
+                }
+                sb.AppendLine(line);
             }
 
-            // Write the string to the stream.
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(nmeaString);
-            MessageStream.Write(data, 0, data.Length);
-
-            // Increment the line counter.
-            _lineCounter = (_lineCounter + 1) % _nmeaStrings.Length;
+            if (sb.Length == 0)
+                return 0;
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
+            count = Math.Min(count, data.Length);
+            Array.Copy(data, 0, buffer, offset, count);
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            return count;
         }
 
-        public void Dispose()
-        {
-            // Dispose of the timer and stream.
-            _timer.Stop();
-            _timer.Dispose();
-            MessageStream.Dispose();
-        }
-    }
+        public override bool CanRead => true;
 
-    public class NmeaMessageEventArgs : EventArgs
-    {
-        public string NmeaMessage { get; set; }
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => -1;
+
+        public override long Position { get => _sr.BaseStream.Position; set => throw new NotImplementedException(); }
+
+        public override void Flush() => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        #endregion
     }
 }

--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -11,6 +11,7 @@ using ArcGIS.Samples.Managers;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Location;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Maui;
 using Esri.ArcGISRuntime.UI;
 using System.Text;
 using System.Timers;
@@ -61,7 +62,12 @@ namespace ArcGIS.Samples.LocationWithNMEA
             _nmeaSource.SentenceReceived += UpdateNmeaMessageLabel;
 
             // Load the map and assign the location datasource.
-            MyMapView.LocationDisplay.DataSource = _nmeaSource;
+            MyMapView.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(MapView.LocationDisplay))
+                    MyMapView.LocationDisplay.DataSource = _nmeaSource;
+            };
+
             try
             {
                 await MyMapView.Map.LoadAsync();
@@ -151,7 +157,8 @@ namespace ArcGIS.Samples.LocationWithNMEA
 
     public class SimulatedNmeaStream : Stream
     {
-        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
+        // The default interval in milliseconds between bursts of NMEA data.
+        private const int DefaultInterval = 1000;
 
         private readonly Timer _timer;
 
@@ -187,7 +194,8 @@ namespace ArcGIS.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                return 0; //Nothing in the buffer to read
+                //Nothing in the buffer to read
+                return 0; 
 
             // Read all the pending bursts of data until we fill up the buffer
             var start = _sr.BaseStream.Position;
@@ -195,7 +203,8 @@ namespace ArcGIS.Samples.LocationWithNMEA
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) 
                 {
                     break;
                 }
@@ -207,7 +216,8 @@ namespace ArcGIS.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            // move the stream position forward only the amount of data we read
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); 
             return count;
         }
 

--- a/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -177,16 +177,16 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                //Nothing in the buffer to read
+                // Nothing in the buffer to read.
                 return 0;
 
-            // Read all the pending bursts of data until we fill up the buffer
+            // Read all the pending bursts of data until we fill up the buffer.
             var start = _sr.BaseStream.Position;
             StringBuilder sb = new StringBuilder();
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver.
                 if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0)
                 {
                     break;
@@ -199,7 +199,7 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            // move the stream position forward only the amount of data we read
+            // Move the stream position forward only the amount of data we read.
             _sr.BaseStream.Seek(start + count, SeekOrigin.Begin);
             return count;
         }

--- a/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
@@ -141,7 +142,7 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
     {
         private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
 
-        private readonly Timer _timer;
+        private readonly System.Timers.Timer _timer;
 
         private readonly StreamReader _sr;
 
@@ -151,7 +152,7 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
         {
             // Populate an array with all of the mock NMEA data.
             _sr = new StreamReader(file);
-            _timer = new Timer(DefaultInterval);            
+            _timer = new System.Timers.Timer(DefaultInterval);            
             _timer.Elapsed += TimerElapsed;
             _timer.Start();
         }

--- a/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -140,7 +140,8 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
 
     public class SimulatedNmeaStream : Stream
     {
-        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
+        // The default interval in milliseconds between bursts of NMEA data.
+        private const int DefaultInterval = 1000;
 
         private readonly System.Timers.Timer _timer;
 
@@ -176,7 +177,8 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                return 0; //Nothing in the buffer to read
+                //Nothing in the buffer to read
+                return 0;
 
             // Read all the pending bursts of data until we fill up the buffer
             var start = _sr.BaseStream.Position;
@@ -184,7 +186,8 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0)
                 {
                     break;
                 }
@@ -196,7 +199,8 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            // move the stream position forward only the amount of data we read
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin);
             return count;
         }
 

--- a/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
@@ -33,15 +34,13 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
     {
         private NmeaLocationDataSource _nmeaSource;
 
-        private NMEAStreamSimulator _simulatedNMEADataSource;
-
         public LocationWithNMEA()
         {
             InitializeComponent();
-            _ = Initialize();
+            Initialize();
         }
 
-        private async Task Initialize()
+        private void Initialize()
         {
             // Add event handler for when this sample is unloaded.
             Unloaded += SampleUnloaded;
@@ -51,40 +50,27 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
             MyMapView.SetViewpoint(new Viewpoint(new MapPoint(-117.191, 34.0306, SpatialReferences.Wgs84), 100000));
 
             // Create the data simulation using stored mock data.
-            _simulatedNMEADataSource = new NMEAStreamSimulator(6.0);
-            _simulatedNMEADataSource.NmeaMessageChanged += UpdateNmeaMessageLabel;
+            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
 
             // Create the NMEA data source.
-            _nmeaSource = new NmeaLocationDataSource(SpatialReferences.Wgs84);
+            _nmeaSource = NmeaLocationDataSource.FromStreamCreator((datasource) => Task.FromResult<Stream>(new SimulatedNmeaStream(nmeaMockDataPath)));
             // To create a NmeaLocationDataSource for a bluetooth device, use the `FromBluetooth` constructor. https://developers.arcgis.com/net/api-reference/api/netwin/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromBluetooth.html
             // To create a NmeaLocationDataSource from a serial port, use the `FromSerialPort` constructor. https://developers.arcgis.com/net/api-reference/api/netwin/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromSerialPort.html
-
-            // Set the location data source to use the stream from the simulator.
-            Stream messageStream = _simulatedNMEADataSource.MessageStream;
-            _nmeaSource.NmeaDataStream = messageStream;
 
             // Create an event handler to update the UI when the location changes.
             _nmeaSource.SatellitesChanged += SatellitesChanged;
             _nmeaSource.LocationChanged += LocationChanged;
+            _nmeaSource.SentenceReceived += UpdateNmeaMessageLabel;
 
-            // Start the location data source.
-            try
-            {
-                MyMapView.LocationDisplay.DataSource = _nmeaSource;
-                await _nmeaSource.StartAsync();
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, ex.Message.GetType().Name, MessageBoxButton.OK, MessageBoxImage.Error);
-            }
+            MyMapView.LocationDisplay.DataSource = _nmeaSource;
         }
 
-        private void UpdateNmeaMessageLabel(object sender, NmeaMessageEventArgs e)
+        private void UpdateNmeaMessageLabel(object sender, string message)
         {
-            Dispatcher.BeginInvoke(new Action(() =>
+            if (message.StartsWith("$GPRMC")) // Display the latest RMC message
             {
-                NmeaMessageLabel.Content = e.NmeaMessage;
-            }));
+                Dispatcher.BeginInvoke(new Action(() => NmeaMessageLabel.Content = message ));
+            }
         }
 
         private void SatellitesChanged(object sender, IReadOnlyList<NmeaSatelliteInfo> infos)
@@ -122,14 +108,13 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
 
         private void StartClick(object sender, RoutedEventArgs e)
         {
-            _simulatedNMEADataSource.Start();
+            _nmeaSource.StartAsync();
             AccuracyLabel.Content = string.Empty;
         }
 
         private void ResetClick(object sender, RoutedEventArgs e)
         {
-            _simulatedNMEADataSource.Stop();
-            _simulatedNMEADataSource.Reset();
+            _nmeaSource.StopAsync();
 
             // Reset the labels.
             AccuracyLabel.Content = "Simulation reset.";
@@ -143,92 +128,95 @@ namespace ArcGIS.WPF.Samples.LocationWithNMEA
         {
             // Stop the location data source.
             MyMapView.LocationDisplay?.DataSource?.StopAsync();
-            _simulatedNMEADataSource?.Dispose();
         }
     }
 
     /*
      * This class uses mock data (an edited recording of a real NMEA data stream) to simulate live NMEA data and create a stream.
      * For NMEA location data sources created from a Bluetooth device or serial input, you may not need to create your own stream.
-     * For any other case, you can write the data to a memory stream like below.
+     * For any other case, you can simulate the datastream from a file like below
      */
 
-    public class NMEAStreamSimulator : IDisposable
+    public class SimulatedNmeaStream : Stream
     {
-        private Timer _timer;
+        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
 
-        public Stream MessageStream;
+        private readonly Timer _timer;
 
-        private int _lineCounter = 0;
-        private const int DefaultInterval = 1000;
+        private readonly StreamReader _sr;
 
-        private string[] _nmeaStrings;
+        private int _pendingBursts = 0;
 
-        public event EventHandler<NmeaMessageEventArgs> NmeaMessageChanged;
-
-        public NMEAStreamSimulator(double speed = 1.0)
+        public SimulatedNmeaStream(string file)
         {
-            _timer = new Timer(DefaultInterval / speed);
-
             // Populate an array with all of the mock NMEA data.
-            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
-            _nmeaStrings = File.ReadAllText(nmeaMockDataPath).Split('\n');
-
-            // Create a data stream for the `NmeaLocationDataSource` to use.
-            MessageStream = new MemoryStream();
-
+            _sr = new StreamReader(file);
+            _timer = new Timer(DefaultInterval);            
             _timer.Elapsed += TimerElapsed;
-        }
-
-        public void Start()
-        {
             _timer.Start();
         }
 
-        public void Stop()
+        private void TimerElapsed(object sender, ElapsedEventArgs e) => _pendingBursts++;
+
+        protected override void Dispose(bool disposing)
         {
-            _timer.Stop();
-        }
-
-        public void Reset()
-        {
-            _timer.Stop();
-            _lineCounter = 0;
-        }
-
-        private void TimerElapsed(object sender, ElapsedEventArgs e)
-        {
-            // Get the next NMEA string and append return and newline characters to it.
-            string nmeaString = $"{_nmeaStrings[_lineCounter]}\r\n";
-
-            NmeaMessageChanged?.Invoke(this, new NmeaMessageEventArgs { NmeaMessage = nmeaString });
-
-            // Check if the start of a new location message.
-            if (nmeaString.StartsWith("$GPGGA"))
+            if (disposing)
             {
-                // Flush any existing NMEA data from the stream.
-                MessageStream.Flush();
+                // Dispose of the timer and stream.
+                _timer.Stop();
+                _timer.Dispose();
+                _sr.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Implementation of a custom System.IO.Stream 
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_pendingBursts == 0)
+                return 0; //Nothing in the buffer to read
+
+            // Read all the pending bursts of data until we fill up the buffer
+            var start = _sr.BaseStream.Position;
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
+            {
+                string line = _sr.ReadLine();
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                {
+                    break;
+                }
+                sb.AppendLine(line);
             }
 
-            // Write the string to the stream.
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(nmeaString);
-            MessageStream.Write(data, 0, data.Length);
-
-            // Increment the line counter.
-            _lineCounter = (_lineCounter + 1) % _nmeaStrings.Length;
+            if (sb.Length == 0)
+                return 0;
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
+            count = Math.Min(count, data.Length);
+            Array.Copy(data, 0, buffer, offset, count);
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            return count;
         }
 
-        public void Dispose()
-        {
-            // Dispose of the timer and stream.
-            _timer.Stop();
-            _timer.Dispose();
-            MessageStream.Dispose();
-        }
-    }
+        public override bool CanRead => true;
 
-    public class NmeaMessageEventArgs : EventArgs
-    {
-        public string NmeaMessage { get; set; }
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => -1;
+
+        public override long Position { get => _sr.BaseStream.Position; set => throw new NotImplementedException(); }
+
+        public override void Flush() => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        #endregion
     }
 }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -175,16 +175,16 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                //Nothing in the buffer to read
+                // Nothing in the buffer to read.
                 return 0;
 
-            // Read all the pending bursts of data until we fill up the buffer
+            // Read all the pending bursts of data until we fill up the buffer.
             var start = _sr.BaseStream.Position;
             StringBuilder sb = new StringBuilder();
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver.
                 if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0)
                 {
                     break;
@@ -197,7 +197,7 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            // move the stream position forward only the amount of data we read
+            // Move the stream position forward only the amount of data we read.
             _sr.BaseStream.Seek(start + count, SeekOrigin.Begin);
             return count;
         }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 
@@ -34,55 +36,40 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
     {
         private NmeaLocationDataSource _nmeaSource;
 
-        private NMEAStreamSimulator _simulatedNMEADataSource;
-
         public LocationWithNMEA()
         {
             InitializeComponent();
-            _ = Initialize();
+            Initialize();
         }
 
-        private async Task Initialize()
+        private void Initialize()
         {
             // Create the map.
             MyMapView.Map = new Map(BasemapStyle.ArcGISNavigation);
             MyMapView.SetViewpoint(new Viewpoint(new MapPoint(-117.191, 34.0306, SpatialReferences.Wgs84), 100000));
 
             // Create the data simulation using stored mock data.
-            _simulatedNMEADataSource = new NMEAStreamSimulator(6.0);
-            _simulatedNMEADataSource.NmeaMessageChanged += UpdateNmeaMessageLabel;
+            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
 
             // Create the NMEA data source.
-            _nmeaSource = new NmeaLocationDataSource(SpatialReferences.Wgs84);
+            _nmeaSource = NmeaLocationDataSource.FromStreamCreator((datasource) => Task.FromResult<Stream>(new SimulatedNmeaStream(nmeaMockDataPath)));
             // To create a NmeaLocationDataSource for a bluetooth device, use the `FromBluetooth` constructor. https://developers.arcgis.com/net/api-reference/api/uwp/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromBluetooth.html
             // To create a NmeaLocationDataSource from a serial port, use the `FromSerialPort` constructor. https://developers.arcgis.com/net/api-reference/api/uwp/Esri.ArcGISRuntime/Esri.ArcGISRuntime.Location.NmeaLocationDataSource.FromSerialPort.html
-
-            // Set the location data source to use the stream from the simulator.
-            Stream messageStream = _simulatedNMEADataSource.MessageStream;
-            _nmeaSource.NmeaDataStream = messageStream;
 
             // Create an event handler to update the UI when the location changes.
             _nmeaSource.SatellitesChanged += SatellitesChanged;
             _nmeaSource.LocationChanged += LocationChanged;
+            _nmeaSource.SentenceReceived += UpdateNmeaMessageLabel;
 
-            // Start the location data source.
-            try
-            {
-                MyMapView.LocationDisplay.DataSource = _nmeaSource;
-                await _nmeaSource.StartAsync();
-            }
-            catch (Exception ex)
-            {
-                await new MessageDialog2(ex.Message, ex.Message.GetType().Name).ShowAsync();
-            }
+            MyMapView.LocationDisplay.DataSource = _nmeaSource;
         }
 
-        private void UpdateNmeaMessageLabel(object sender, NmeaMessageEventArgs e)
+        private void UpdateNmeaMessageLabel(object sender, string message)
         {
-            DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
+            if (message.StartsWith("$GPRMC")) // Display the latest RMC message
             {
-                NmeaMessageLabel.Text = e.NmeaMessage;
-            });
+                DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () => NmeaMessageLabel.Text = message);
+            }
         }
 
         private void SatellitesChanged(object sender, IReadOnlyList<NmeaSatelliteInfo> infos)
@@ -120,14 +107,13 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
 
         private void StartClick(object sender, RoutedEventArgs e)
         {
-            _simulatedNMEADataSource.Start();
+            _nmeaSource.StartAsync();
             AccuracyLabel.Text = string.Empty;
         }
 
         private void ResetClick(object sender, RoutedEventArgs e)
         {
-            _simulatedNMEADataSource.Stop();
-            _simulatedNMEADataSource.Reset();
+            _nmeaSource.StopAsync();
 
             // Reset the labels.
             AccuracyLabel.Text = "Simulation reset.";
@@ -141,92 +127,95 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
         {
             // Stop the location data source.
             MyMapView.LocationDisplay?.DataSource?.StopAsync();
-            _simulatedNMEADataSource?.Dispose();
         }
     }
 
     /*
      * This class uses mock data (an edited recording of a real NMEA data stream) to simulate live NMEA data and create a stream.
      * For NMEA location data sources created from a Bluetooth device or serial input, you may not need to create your own stream.
-     * For any other case, you can write the data to a memory stream like below.
+     * For any other case, you can simulate the datastream from a file like below
      */
 
-    public class NMEAStreamSimulator : IDisposable
+    public class SimulatedNmeaStream : Stream
     {
-        private Timer _timer;
+        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
 
-        public Stream MessageStream;
+        private readonly System.Timers.Timer _timer;
 
-        private int _lineCounter = 0;
-        private const int DefaultInterval = 1000;
+        private readonly StreamReader _sr;
 
-        private string[] _nmeaStrings;
+        private int _pendingBursts = 0;
 
-        public event EventHandler<NmeaMessageEventArgs> NmeaMessageChanged;
-
-        public NMEAStreamSimulator(double speed = 1.0)
+        public SimulatedNmeaStream(string file)
         {
-            _timer = new Timer(DefaultInterval / speed);
-
             // Populate an array with all of the mock NMEA data.
-            string nmeaMockDataPath = DataManager.GetDataFolder("d5bad9f4fee9483791e405880fb466da", "Redlands.nmea");
-            _nmeaStrings = File.ReadAllText(nmeaMockDataPath).Split('\n');
-
-            // Create a data stream for the `NmeaLocationDataSource` to use.
-            MessageStream = new MemoryStream();
-
+            _sr = new StreamReader(file);
+            _timer = new System.Timers.Timer(DefaultInterval);
             _timer.Elapsed += TimerElapsed;
-        }
-
-        public void Start()
-        {
             _timer.Start();
         }
 
-        public void Stop()
+        private void TimerElapsed(object sender, ElapsedEventArgs e) => Interlocked.Increment(ref _pendingBursts);
+
+        protected override void Dispose(bool disposing)
         {
-            _timer.Stop();
-        }
-
-        public void Reset()
-        {
-            _timer.Stop();
-            _lineCounter = 0;
-        }
-
-        private void TimerElapsed(object sender, ElapsedEventArgs e)
-        {
-            // Get the next NMEA string and append return and newline characters to it.
-            string nmeaString = $"{_nmeaStrings[_lineCounter]}\r\n";
-
-            NmeaMessageChanged?.Invoke(this, new NmeaMessageEventArgs { NmeaMessage = nmeaString });
-
-            // Check if the start of a new location message.
-            if (nmeaString.StartsWith("$GPGGA"))
+            if (disposing)
             {
-                // Flush any existing NMEA data from the stream.
-                MessageStream.Flush();
+                // Dispose of the timer and stream.
+                _timer.Stop();
+                _timer.Dispose();
+                _sr.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Implementation of a custom System.IO.Stream 
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_pendingBursts == 0)
+                return 0; //Nothing in the buffer to read
+
+            // Read all the pending bursts of data until we fill up the buffer
+            var start = _sr.BaseStream.Position;
+            StringBuilder sb = new StringBuilder();
+            while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
+            {
+                string line = _sr.ReadLine();
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                {
+                    break;
+                }
+                sb.AppendLine(line);
             }
 
-            // Write the string to the stream.
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(nmeaString);
-            MessageStream.Write(data, 0, data.Length);
-
-            // Increment the line counter.
-            _lineCounter = (_lineCounter + 1) % _nmeaStrings.Length;
+            if (sb.Length == 0)
+                return 0;
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
+            count = Math.Min(count, data.Length);
+            Array.Copy(data, 0, buffer, offset, count);
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            return count;
         }
 
-        public void Dispose()
-        {
-            // Dispose of the timer and stream.
-            _timer.Stop();
-            _timer.Dispose();
-            MessageStream.Dispose();
-        }
-    }
+        public override bool CanRead => true;
 
-    public class NmeaMessageEventArgs : EventArgs
-    {
-        public string NmeaMessage { get; set; }
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => -1;
+
+        public override long Position { get => _sr.BaseStream.Position; set => throw new NotImplementedException(); }
+
+        public override void Flush() => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        #endregion
     }
 }

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -138,7 +138,8 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
 
     public class SimulatedNmeaStream : Stream
     {
-        private const int DefaultInterval = 1000; // he default interval in milliseconds between bursts of NMEA data.
+        // The default interval in milliseconds between bursts of NMEA data.
+        private const int DefaultInterval = 1000;
 
         private readonly System.Timers.Timer _timer;
 
@@ -174,7 +175,8 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_pendingBursts == 0)
-                return 0; //Nothing in the buffer to read
+                //Nothing in the buffer to read
+                return 0;
 
             // Read all the pending bursts of data until we fill up the buffer
             var start = _sr.BaseStream.Position;
@@ -182,7 +184,8 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
             while (sb.Length < count && !_sr.EndOfStream && _pendingBursts > 0)
             {
                 string line = _sr.ReadLine();
-                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0) // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                // In this sample we pause the burst of messages for each GGA message to simulate the break in the nmea stream on a receiver
+                if (line.StartsWith("$GPGGA,") && Interlocked.Decrement(ref _pendingBursts) == 0)
                 {
                     break;
                 }
@@ -194,7 +197,8 @@ namespace ArcGIS.WinUI.Samples.LocationWithNMEA
             byte[] data = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
             count = Math.Min(count, data.Length);
             Array.Copy(data, 0, buffer, offset, count);
-            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin); // move the stream position forward only the amount of data we read
+            // move the stream position forward only the amount of data we read
+            _sr.BaseStream.Seek(start + count, SeekOrigin.Begin);
             return count;
         }
 


### PR DESCRIPTION
# Description

The current sample is writing and reading the same stream, causing threading issues and many messages skipped.
The new implementation better simulates a real-world stream by writing messages in burst.

## Type of change

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
