### PR TITLE
Remove use of obsolete APIs in XAML

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml
+++ b/src/WPF/WPF.Viewer/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml
@@ -10,13 +10,8 @@
         </Style>
     </UserControl.Resources>
     <Grid>
-        <esri:MapView x:Name="MyMapView">
-            <mapping:Map>
-                <mapping:Map.OperationalLayers>
-                    <mapping:ArcGISTiledLayer x:Name="Basemap" Source="https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer" />
-                </mapping:Map.OperationalLayers>
-            </mapping:Map>
-        </esri:MapView>
+        <esri:MapView x:Name="MyMapView" />
+
         <Border Style="{StaticResource BorderStyle}">
             <Grid>
                 <Grid.RowDefinitions>

--- a/src/WPF/WPF.Viewer/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
@@ -53,6 +53,7 @@ namespace ArcGIS.WPF.Samples.ChangeViewpoint
         public ChangeViewpoint()
         {
             InitializeComponent();
+            MyMapView.Map = new Map(BasemapStyle.ArcGISTopographic);
         }
 
         private async void OnButtonClick(object sender, RoutedEventArgs e)
@@ -83,7 +84,7 @@ namespace ArcGIS.WPF.Samples.ChangeViewpoint
 
                         // Navigate to full extent of the first baselayer before animating to specified geometry
                         await MyMapView.SetViewpointAsync(
-                            new Viewpoint(Basemap.FullExtent));
+                            new Viewpoint(MyMapView.Map.Basemap.BaseLayers[0].FullExtent));
 
                         // Create a new Viewpoint using the specified geometry
                         Viewpoint viewpoint = new Viewpoint(_edinburghEnvelope);

--- a/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml
+++ b/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml
@@ -4,17 +4,7 @@
              xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
              xmlns:mapping="clr-namespace:Esri.ArcGISRuntime.Mapping;assembly=Esri.ArcGISRuntime">
     <Grid x:Name="layoutGrid">
-        <esri:MapView x:Name="MyMapView">
-            <mapping:Map>
-                <mapping:Map.OperationalLayers>
-                    <!--  This layer is public and does not require credentials  -->
-                    <mapping:ArcGISTiledLayer Name="World Street Map - Public" Source="https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer" />
-                    <!--  This layer is secured with ArcGIS tokens and requires a login  -->
-                    <!--  username: user1 | password: user1  -->
-                    <mapping:ArcGISMapImageLayer Name="USA - Secure" Source="https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA_secure_user1/MapServer" />
-                </mapping:Map.OperationalLayers>
-            </mapping:Map>
-        </esri:MapView>
+        <esri:MapView x:Name="MyMapView" />
 
         <!--  Layer listing with status  -->
         <Border Style="{StaticResource BorderStyle}">

--- a/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -7,6 +7,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Security;
 using System;
 using System.ComponentModel;
@@ -33,22 +34,19 @@ namespace ArcGIS.WPF.Samples.TokenSecuredChallenge
 
             // Define a method to challenge the user for credentials when a secured resource is encountered.
             AuthenticationManager.Current.ChallengeHandler = new ChallengeHandler(Challenge);
+
+            // This layer is public and does not require credentials
+            MyMapView.Map = new Map(new Basemap(new ArcGISTiledLayer(new Uri("https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer"))));
+            // This layer is secured with ArcGIS tokens and requires a login
+            // username: user1 | password: user1
+            MyMapView.Map.OperationalLayers.Add(new ArcGISMapImageLayer(new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA_secure_user1/MapServer")) { Name = "USA - Secure" });
         }
 
         // Function that's called when authentication is needed for a secure resource.
-        private async Task<Credential> Challenge(CredentialRequestInfo info)
+        private Task<Credential> Challenge(CredentialRequestInfo info)
         {
-            // Make sure to run on the UI thread.
-            if (this.Dispatcher == null)
-            {
-                // No current dispatcher, code is already running on the UI thread.
-                return await GetUserCredentialsFromUI(info);
-            }
-            else
-            {
-                // Use the dispatcher to invoke the challenge UI.
-                return await this.Dispatcher.Invoke(() => GetUserCredentialsFromUI(info));
-            }
+            // Use the dispatcher to invoke the challenge on the UI thread.
+            return this.Dispatcher.Invoke(() => GetUserCredentialsFromUI(info));
         }
 
         private async Task<Credential> GetUserCredentialsFromUI(CredentialRequestInfo info)


### PR DESCRIPTION
# Description

XAML creation of layers is no longer supported and the constructors used for it has been obsolete for a while.
Also simplified authentication callback by removing unnecessary code that was never called.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
