### PR TITLE
Don't generate redirect links for new samples

### DIFF
--- a/tools/metadata_tools/sample_metadata.py
+++ b/tools/metadata_tools/sample_metadata.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import os
 import re
-from slugify import slugify
 
 class sample_metadata:
     
@@ -28,11 +27,6 @@ class sample_metadata:
 
     def __init__(self):
         self.reset_props()
-        try:
-            import slugify
-        except ModuleNotFoundError:
-            print("Module `slugify` is not installed")
-            self.install("python-slugify")
 
     def install(self, package):
         subprocess.check_call([sys.executable, "-m", "pip", "install", package])
@@ -83,7 +77,6 @@ class sample_metadata:
         # formal name is the name of the folder containing the json
         pathparts = sample_metadata.splitall(path_to_readme)
         self.formal_name = pathparts[-2]
-        slugged_sample_name = slugify(self.friendly_name)
 
         # Load existing metadata if present
         if os.path.exists(path_to_json):
@@ -91,12 +84,6 @@ class sample_metadata:
                 existing_metadata = json.load(json_file)
                 if "redirect_from" in existing_metadata:
                     self.redirect_from = existing_metadata["redirect_from"]
-
-        # populate redirect_from; it is based on a pattern
-        real_platform = platform
-        redirect_string = f"/net/latest/{real_platform.lower()}/sample-code/{slugged_sample_name}.htm"
-        if redirect_string not in self.redirect_from:
-            self.redirect_from.append(redirect_string)
 
         # category is the name of the folder containing the sample folder
         self.category = pathparts[-3]

--- a/tools/metadata_tools/sample_metadata.py
+++ b/tools/metadata_tools/sample_metadata.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import os
 import re
+from slugify import slugify
 
 class sample_metadata:
     
@@ -27,6 +28,11 @@ class sample_metadata:
 
     def __init__(self):
         self.reset_props()
+        try:
+            import slugify
+        except ModuleNotFoundError:
+            print("Module `slugify` is not installed")
+            self.install("python-slugify")
 
     def install(self, package):
         subprocess.check_call([sys.executable, "-m", "pip", "install", package])
@@ -77,6 +83,7 @@ class sample_metadata:
         # formal name is the name of the folder containing the json
         pathparts = sample_metadata.splitall(path_to_readme)
         self.formal_name = pathparts[-2]
+        slugged_sample_name = slugify(self.friendly_name)
 
         # Load existing metadata if present
         if os.path.exists(path_to_json):

--- a/tools/sample_generator/templates/default/readme.metadata.json
+++ b/tools/sample_generator/templates/default/readme.metadata.json
@@ -6,12 +6,9 @@
     "images": [
         "sample_name.jpg"
     ],
-    "keywords": [
-    ],
+    "keywords": [],
     "redirect_from": [],
-    "relevant_apis": [
-    ],
-    "snippets": [
-    ],
+    "relevant_apis": [],
+    "snippets": [],
     "title": "friendly_name"
 }

--- a/tools/sample_generator/templates/default/readme.metadata.json
+++ b/tools/sample_generator/templates/default/readme.metadata.json
@@ -8,9 +8,7 @@
     ],
     "keywords": [
     ],
-    "redirect_from": [
-        "/net/wpf/sample-code/sample_name.htm"
-    ],
+    "redirect_from": [],
     "relevant_apis": [
     ],
     "snippets": [


### PR DESCRIPTION
# Description

Redirect links should not be generated for new samples because new samples don't have old pages. Users won't have a bookmark for a page which never existed. 

This Swift sample metadata demonstrates this https://github.com/Esri/arcgis-maps-sdk-swift-samples/blob/main/Shared/Samples/Show%20shapefile%20metadata/README.metadata.json#L27

Consolidated samples and old samples still require redirect links to be maintained; this behavior change is just for new samples.

Also fixed the metadata template since empty lists end up being one lines after running sample sync script. This will reduce diff between commits.

## Type of change

- Bug fix

## Testing

Tested by "creating" the `Apply renderers to scene layer` sample.
