### PR TITLE
[WPF] Fix sample descriptions not updating

### DIFF
--- a/src/WPF/WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/WPF.Viewer/Description.xaml.cs
@@ -34,7 +34,10 @@ namespace ArcGIS.WPF.Viewer
             string htmlString = "<!doctype html><head><base href=\"" + readmePath + "\"><link rel=\"stylesheet\" href=\"" + cssPath + "\" /><link rel=\"stylesheet\" href=\"" + overrideCssPath + "\" /></head><body class=\"markdown-body\">" + readmeContent + "</body>";
 
             // Set the html in web browser.
-            DescriptionView.DocumentText = htmlString;
+            DescriptionView.Navigate("about:blank");
+            DescriptionView.Document.OpenNew(false);
+            DescriptionView.Document.Write(htmlString);
+            DescriptionView.Refresh();
 
             // Disable navigation in the web browser control.
             // This prevents script errors when users click links in READMEs.


### PR DESCRIPTION
# Description

Currently the WPF sample viewer does not update the Description window after loading the first sample. This branch fixes that.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files