### PR TITLE
Fix load button being unreachable on some screen resolutions in Create dynamic basemap gallery

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
@@ -21,7 +21,7 @@
                 Clicked="ShowGallery_Clicked"
                 FontSize="{OnIdiom Default=80,
                                    Phone=50}"
-                HorizontalOptions="Start"
+                HorizontalOptions="End"
                 TextColor="White"
                 ToolTipProperties.Text="Show Gallery"
                 VerticalOptions="Start"
@@ -33,17 +33,8 @@
                 <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
             </Border.GestureRecognizers>
         </Border>
-        <StackLayout x:Name="DynamicBasemapStyleGallery"
-                     Margin="5"
-                     Padding="5"
-                     Background="{AppThemeBinding Light=#dfdfdf,
-                                                  Dark=#303030}"
-                     IsVisible="False"
-                     MaximumHeightRequest="{OnIdiom Default=850,
-                                                    Phone=650}"
-                     MaximumWidthRequest="{OnIdiom Default=400,
-                                                   Phone=300}"
-                     Spacing="5">
+
+        <Grid x:Name="DynamicBasemapStyleGallery" IsVisible="False" RowDefinitions="*,*" Background="{AppThemeBinding Light=#dfdfdf, Dark=#303030}">
             <CollectionView x:Name="BasemapStyleGallery"
                             Margin="5"
                             MaximumHeightRequest="{OnIdiom Default=500,
@@ -53,37 +44,42 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="esri:BasemapStyleInfo">
                         <StackLayout Margin="5">
-                            <Label FontAttributes="Bold" Text="{Binding StyleName}" />
-                            <Image HeightRequest="{OnIdiom Default=200,
-                                                           Phone=150}"
-                                   HorizontalOptions="Start"
+                            <Label FontAttributes="Bold" Text="{Binding StyleName}" HorizontalOptions="Center" />
+                            <Image HeightRequest="{OnIdiom Default=100,
+                                                           Phone=75}"
+                                   HorizontalOptions="Center"
                                    Source="{Binding Thumbnail, Converter={StaticResource RuntimeImageToImageSource}}" />
                         </StackLayout>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
-            <Label FontAttributes="Bold" Text="Language strategy:" />
-            <Picker x:Name="StrategyPicker"
-                    Margin="5"
-                    HorizontalOptions="Fill"
-                    IsEnabled="False" />
-            <Label Margin="5"
-                   FontAttributes="Bold"
-                   Text="Language:" />
-            <Picker x:Name="LanguagePicker"
-                    Margin="5"
-                    HorizontalOptions="Fill"
-                    IsEnabled="False"
-                    ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:BasemapStyleLanguageInfo}" />
-            <Label FontAttributes="Bold" Text="Worldview:" />
-            <Picker x:Name="WorldviewPicker"
-                    Margin="5"
-                    HorizontalOptions="Fill"
-                    IsEnabled="False"
-                    ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:Worldview}" />
-            <Button Margin="5"
-                    Clicked="LoadButton_Click"
-                    Text="Load" />
-        </StackLayout>
+
+            <StackLayout MaximumWidthRequest="{OnIdiom Default=400, Phone=300}"
+                         Spacing="5" Grid.Row="1">
+                <Label FontAttributes="Bold" Text="Language strategy:" />
+                <Picker x:Name="StrategyPicker"
+                        Margin="5"
+                        HorizontalOptions="Fill"
+                        IsEnabled="False" />
+                <Label Margin="5"
+                       FontAttributes="Bold"
+                       Text="Language:" />
+                <Picker x:Name="LanguagePicker"
+                        Margin="5"
+                        HorizontalOptions="Fill"
+                        IsEnabled="False"
+                        ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:BasemapStyleLanguageInfo}" />
+                <Label FontAttributes="Bold" Text="Worldview:" />
+                <Picker x:Name="WorldviewPicker"
+                        Margin="5"
+                        HorizontalOptions="Fill"
+                        IsEnabled="False"
+                        ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:Worldview}" />
+                <Button Margin="5"
+                        Clicked="LoadButton_Click"
+                        Text="Load" />
+            </StackLayout>
+
+        </Grid>
     </Grid>
 </ContentPage>

--- a/src/WPF/WPF.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
+++ b/src/WPF/WPF.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
@@ -5,37 +5,44 @@
     <Grid>
         <esri:MapView x:Name="MyMapView" />
         <Border Style="{StaticResource BorderStyle}">
-            <StackPanel>
-                <StackPanel Margin="5">
-                    <ListView x:Name="BasemapStyleGallery"
-                              MaxHeight="500"
-                              SelectionMode="Single">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Margin="5">
-                                    <Label Content="{Binding StyleName}" FontWeight="Bold" />
-                                    <Image Height="125"
-                                           HorizontalAlignment="Left"
-                                           Source="{Binding Thumbnail.Source}" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <Label Content="Language strategy:" FontWeight="Bold" />
-                    <ComboBox x:Name="StrategyPicker" IsEnabled="False" />
-                    <Label Content="Language:" FontWeight="Bold" />
-                    <ComboBox x:Name="LanguagePicker"
-                              DisplayMemberPath="DisplayName"
-                              IsEnabled="False" />
-                    <Label Content="Worldview:" FontWeight="Bold" />
-                    <ComboBox x:Name="WorldviewPicker"
-                              DisplayMemberPath="DisplayName"
-                              IsEnabled="False" />
-                    <Button Margin="0,10,0,0"
-                            Click="LoadButton_Click"
-                            Content="Load" />
-                </StackPanel>
-            </StackPanel>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <ListView x:Name="BasemapStyleGallery"
+                          SelectionMode="Single">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="5">
+                                <Label Content="{Binding StyleName}" FontWeight="Bold" />
+                                <Image Height="100"
+                                       HorizontalAlignment="Left"
+                                       Source="{Binding Thumbnail.Source}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <Label Content="Language strategy:" FontWeight="Bold" />
+                        <ComboBox x:Name="StrategyPicker" IsEnabled="False" />
+                        <Label Content="Language:" FontWeight="Bold" />
+                        <ComboBox x:Name="LanguagePicker"
+                                  DisplayMemberPath="DisplayName"
+                                  IsEnabled="False" />
+                        <Label Content="Worldview:" FontWeight="Bold" />
+                        <ComboBox x:Name="WorldviewPicker"
+                                  DisplayMemberPath="DisplayName"
+                                  IsEnabled="False" />
+                        <Button Margin="0,10,0,0"
+                                Click="LoadButton_Click"
+                                Content="Load" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>
         </Border>
     </Grid>
 </UserControl>

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
@@ -8,42 +8,50 @@
     <Grid>
         <esriControls:MapView x:Name="MyMapView" />
         <Border Style="{StaticResource BorderStyle}">
-            <StackPanel>
-                <StackPanel Margin="5" Spacing="5">
-                    <ListView x:Name="BasemapStyleGallery"
-                              MaxHeight="500"
-                              SelectionMode="Single">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="mapping:BasemapStyleInfo">
-                                <StackPanel Margin="5">
-                                    <TextBlock FontWeight="Bold" Text="{Binding StyleName}" />
-                                    <Image Height="150"
-                                           HorizontalAlignment="Left"
-                                           Source="{x:Bind esriUI:RuntimeImageExtensions.ToImageSource(Thumbnail)}" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <TextBlock FontWeight="Bold" Text="Language strategy:" />
-                    <ComboBox x:Name="StrategyPicker"
-                              HorizontalAlignment="Stretch"
-                              IsEnabled="False" />
-                    <TextBlock FontWeight="Bold" Text="Language:" />
-                    <ComboBox x:Name="LanguagePicker"
-                              HorizontalAlignment="Stretch"
-                              DisplayMemberPath="DisplayName"
-                              IsEnabled="False" />
-                    <TextBlock FontWeight="Bold" Text="Worldview:" />
-                    <ComboBox x:Name="WorldviewPicker"
-                              HorizontalAlignment="Stretch"
-                              DisplayMemberPath="DisplayName"
-                              IsEnabled="False" />
-                    <Button Margin="0,10,0,0"
-                            HorizontalAlignment="Stretch"
-                            Click="LoadButton_Click"
-                            Content="Load" />
-                </StackPanel>
-            </StackPanel>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <ListView x:Name="BasemapStyleGallery"
+                            MaxHeight="500"
+                            SelectionMode="Single">
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="mapping:BasemapStyleInfo">
+                            <StackPanel Margin="5">
+                                <TextBlock FontWeight="Bold" Text="{Binding StyleName}" />
+                                <Image Height="100"
+                                        HorizontalAlignment="Left"
+                                        Source="{x:Bind esriUI:RuntimeImageExtensions.ToImageSource(Thumbnail)}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <ScrollView Grid.Row="1">
+                    <StackPanel Margin="5" Spacing="5">
+                        <TextBlock FontWeight="Bold" Text="Language strategy:" />
+                        <ComboBox x:Name="StrategyPicker"
+                                  HorizontalAlignment="Stretch"
+                                  IsEnabled="False" />
+                        <TextBlock FontWeight="Bold" Text="Language:" />
+                        <ComboBox x:Name="LanguagePicker"
+                                  HorizontalAlignment="Stretch"
+                                  DisplayMemberPath="DisplayName"
+                                  IsEnabled="False" />
+                        <TextBlock FontWeight="Bold" Text="Worldview:" />
+                        <ComboBox x:Name="WorldviewPicker"
+                                  HorizontalAlignment="Stretch"
+                                  DisplayMemberPath="DisplayName"
+                                  IsEnabled="False" />
+                        <Button Margin="0,10,0,0"
+                                HorizontalAlignment="Stretch"
+                                Click="LoadButton_Click"
+                                Content="Load" />
+                    </StackPanel>
+                </ScrollView>
+            </Grid>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
# Description

This came up during testing for a feature team. Probably best to review with the whitespace diff toggled [off](https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/pull/1846/changes?w=1).

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
